### PR TITLE
Add permalink: pretty as default option in the _config.yml template.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -56,6 +56,7 @@ defaults:
       tooltip: true
 
 sidebars: [home_sidebar]
+permalink: pretty
 
 #theme: jekyll-theme-cayman
 

--- a/nbdev/template.py
+++ b/nbdev/template.py
@@ -104,6 +104,7 @@ defaults:
 
 sidebars:
 - home_sidebar
+permalink: pretty
 
 theme: jekyll-theme-cayman"""
 


### PR DESCRIPTION
When trying to deploy the nbdev documentation to an authenticated heroku app (using https://github.com/benbalter/jekyll-auth) it turned out that the extensionless URLs in the menu didn't work. When I manually added `.html` to the end of the URL I did find the page.

This was easily fixed (although it took some time to find this solution) by adding a parameter `permalink: pretty` to `_config.yml`.