### PR TITLE
add option to format docstring as monospace

### DIFF
--- a/docs/showdoc.html
+++ b/docs/showdoc.html
@@ -1380,7 +1380,7 @@ summary: "Functions to show the doc cells in notebooks"
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p><code>doc_string</code> determines if we show the docstring of the function or not. <code>name</code> can be used to provide an alternative to the name automatically found. <code>title_level</code> determines the level of the anchor (default 3 for classes and 4 for functions). If <code>disp</code> is <code>False</code>, the function returns the markdown code instead of displaying it.</p>
+<p><code>doc_string</code> determines if we show the docstring of the function or not. <code>name</code> can be used to provide an alternative to the name automatically found. <code>title_level</code> determines the level of the anchor (default 3 for classes and 4 for functions). If <code>disp</code> is <code>False</code>, the function returns the markdown code instead of displaying it. If <code>doc_string</code> is <code>True</code> and <code>monospace_docstrings</code> is set to <code>True</code> in <code>settings.ini</code>, the docstring of the function is formatted in a code block to preserve whitespace.</p>
 
 </div>
 </div>
@@ -1416,7 +1416,7 @@ summary: "Functions to show the doc cells in notebooks"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="md2html" class="doc_header"><code>md2html</code><a href="https://github.com/fastai/nbdev/tree/master/nbdev/showdoc.py#L249" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>md2html</code>(<strong><code>md</code></strong>)</p>
+<h4 id="md2html" class="doc_header"><code>md2html</code><a href="https://github.com/fastai/nbdev/tree/master/nbdev/showdoc.py#L253" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>md2html</code>(<strong><code>md</code></strong>)</p>
 </blockquote>
 <p>Convert markdown <code>md</code> to HTML code</p>
 
@@ -1429,36 +1429,24 @@ summary: "Functions to show the doc cells in notebooks"
 
 </div>
 <div class="cell border-box-sizing code_cell rendered">
-<div class="input">
-
-<div class="inner_cell">
-    <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">fastai2.data.core</span> <span class="k">import</span> <span class="n">TfmdDL</span>
-</pre></div>
-
-    </div>
-</div>
-</div>
 
 </div>
 <div class="cell border-box-sizing code_cell rendered">
-<div class="input">
 
-<div class="inner_cell">
-    <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="k">def</span> <span class="nf">get_doc_link</span><span class="p">(</span><span class="n">func</span><span class="p">):</span>
-    <span class="n">mod</span> <span class="o">=</span> <span class="n">inspect</span><span class="o">.</span><span class="n">getmodule</span><span class="p">(</span><span class="n">func</span><span class="p">)</span>
-    <span class="n">module</span> <span class="o">=</span> <span class="n">mod</span><span class="o">.</span><span class="vm">__name__</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="s1">&#39;.&#39;</span><span class="p">,</span> <span class="s1">&#39;/&#39;</span><span class="p">)</span> <span class="o">+</span> <span class="s1">&#39;.py&#39;</span>
-    <span class="k">try</span><span class="p">:</span>
-        <span class="n">nbdev_mod</span> <span class="o">=</span> <span class="n">importlib</span><span class="o">.</span><span class="n">import_module</span><span class="p">(</span><span class="n">mod</span><span class="o">.</span><span class="n">__package__</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;.&#39;</span><span class="p">)[</span><span class="mi">0</span><span class="p">]</span> <span class="o">+</span> <span class="s1">&#39;._nbdev&#39;</span><span class="p">)</span>
-        <span class="n">try_pack</span> <span class="o">=</span> <span class="n">source_nb</span><span class="p">(</span><span class="n">func</span><span class="p">,</span> <span class="n">mod</span><span class="o">=</span><span class="n">nbdev_mod</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">try_pack</span><span class="p">:</span>
-            <span class="n">page</span> <span class="o">=</span> <span class="s1">&#39;.&#39;</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">try_pack</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;_&#39;</span><span class="p">)[</span><span class="mi">1</span><span class="p">:])</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="s1">&#39;.ipynb&#39;</span><span class="p">,</span> <span class="s1">&#39;&#39;</span><span class="p">)</span>
-            <span class="k">return</span> <span class="n">f</span><span class="s1">&#39;</span><span class="si">{nbdev_mod.doc_url}{page}</span><span class="s1">#{qual_name(func)}&#39;</span>
-    <span class="k">except</span><span class="p">:</span> <span class="k">return</span> <span class="kc">None</span>
-</pre></div>
+<div class="output_wrapper">
+<div class="output">
 
-    </div>
+<div class="output_area">
+
+
+<div class="output_markdown rendered_html output_subarea ">
+<h4 id="get_doc_link" class="doc_header"><code>get_doc_link</code><a href="https://github.com/fastai/nbdev/tree/master/nbdev/showdoc.py#L260" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>get_doc_link</code>(<strong><code>func</code></strong>)</p>
+</blockquote>
+
+</div>
+
+</div>
+
 </div>
 </div>
 
@@ -1503,7 +1491,7 @@ summary: "Functions to show the doc cells in notebooks"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="doc" class="doc_header"><code>doc</code><a href="https://github.com/fastai/nbdev/tree/master/nbdev/showdoc.py#L256" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>doc</code>(<strong><code>elt</code></strong>)</p>
+<h4 id="doc" class="doc_header"><code>doc</code><a href="https://github.com/fastai/nbdev/tree/master/nbdev/showdoc.py#L272" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>doc</code>(<strong><code>elt</code></strong>)</p>
 </blockquote>
 <p>Show <a href="/showdoc#show_doc"><code>show_doc</code></a> info in preview window when used in a notebook</p>
 

--- a/nbdev/showdoc.py
+++ b/nbdev/showdoc.py
@@ -241,7 +241,11 @@ def show_doc(elt, doc_string=True, name=None, title_level=None, disp=True, defau
     title_level = title_level or (default_cls_level if inspect.isclass(elt) else 4)
     doc =  f'<h{title_level} id="{qname}" class="doc_header">{name}{source_link}</h{title_level}>'
     doc += f'\n\n> {args}\n\n' if len(args) > 0 else '\n\n'
-    if doc_string and inspect.getdoc(elt): doc += add_doc_links(inspect.getdoc(elt))
+    if doc_string and inspect.getdoc(elt):
+        s = inspect.getdoc(elt)
+        # doc links don't work inside markdown pre/code blocks
+        s = f'```\n{s}\n```' if Config().get('monospace_docstrings') == 'True' else add_doc_links(s)
+        doc += s
     if disp: display(Markdown(doc))
     else: return doc
 

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -1426,7 +1426,11 @@
     "    title_level = title_level or (default_cls_level if inspect.isclass(elt) else 4)\n",
     "    doc =  f'<h{title_level} id=\"{qname}\" class=\"doc_header\">{name}{source_link}</h{title_level}>'\n",
     "    doc += f'\\n\\n> {args}\\n\\n' if len(args) > 0 else '\\n\\n'\n",
-    "    if doc_string and inspect.getdoc(elt): doc += add_doc_links(inspect.getdoc(elt))\n",
+    "    if doc_string and inspect.getdoc(elt):\n",
+    "        s = inspect.getdoc(elt)\n",
+    "        # doc links don't work inside markdown pre/code blocks\n",
+    "        s = f'```\\n{s}\\n```' if Config().get('monospace_docstrings') == 'True' else add_doc_links(s)\n",
+    "        doc += s\n",
     "    if disp: display(Markdown(doc))\n",
     "    else: return doc"
    ]
@@ -1435,7 +1439,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`doc_string` determines if we show the docstring of the function or not. `name` can be used to provide an alternative to the name automatically found. `title_level` determines the level of the anchor (default 3 for classes and 4 for functions). If `disp` is `False`, the function returns the markdown code instead of displaying it."
+    "`doc_string` determines if we show the docstring of the function or not. `name` can be used to provide an alternative to the name automatically found. `title_level` determines the level of the anchor (default 3 for classes and 4 for functions). If `disp` is `False`, the function returns the markdown code instead of displaying it. If `doc_string` is `True` and `monospace_docstrings` is set to `True` in `settings.ini`, the docstring of the function is formatted in a code block to preserve whitespace."
    ]
   },
   {
@@ -1470,7 +1474,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h2 id=\"DocsTestClass\" class=\"doc_header\"><code>class</code> <code>DocsTestClass</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L375\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\n",
+       "<h2 id=\"DocsTestClass\" class=\"doc_header\"><code>class</code> <code>DocsTestClass</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L376\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\n",
        "\n",
        "> <code>DocsTestClass</code>()\n",
        "\n"
@@ -1496,7 +1500,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"DocsTestClass.test\" class=\"doc_header\"><code>DocsTestClass.test</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L376\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"DocsTestClass.test\" class=\"doc_header\"><code>DocsTestClass.test</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L377\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>DocsTestClass.test</code>()\n",
        "\n"
@@ -1522,7 +1526,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"notebook2script\" class=\"doc_header\"><code>notebook2script</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L357\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"notebook2script\" class=\"doc_header\"><code>notebook2script</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L358\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>notebook2script</code>(**`fname`**=*`None`*, **`silent`**=*`False`*, **`to_dict`**=*`False`*)\n",
        "\n",
@@ -1566,6 +1570,75 @@
    "source": [
     "#hide\n",
     "show_doc(check_re)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"test_func_with_args_and_links\" class=\"doc_header\"><code>test_func_with_args_and_links</code><a href=\"__main__.py#L2\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>test_func_with_args_and_links</code>(**`foo`**, **`bar`**)\n",
+       "\n",
+       "Doc link: [`show_doc`](/showdoc#show_doc).\n",
+       "Args:\n",
+       "    foo: foo\n",
+       "    bar: bar\n",
+       "Returns:\n",
+       "    None"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"test_func_with_args_and_links\" class=\"doc_header\"><code>test_func_with_args_and_links</code><a href=\"__main__.py#L2\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>test_func_with_args_and_links</code>(**`foo`**, **`bar`**)\n",
+       "\n",
+       "```\n",
+       "Doc link: `show_doc`.\n",
+       "Args:\n",
+       "    foo: foo\n",
+       "    bar: bar\n",
+       "Returns:\n",
+       "    None\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#hide\n",
+    "def test_func_with_args_and_links(foo, bar):\n",
+    "    \"\"\"\n",
+    "    Doc link: `show_doc`.\n",
+    "    Args:\n",
+    "        foo: foo\n",
+    "        bar: bar\n",
+    "    Returns:\n",
+    "        None\n",
+    "    \"\"\"\n",
+    "    pass\n",
+    "\n",
+    "show_doc(test_func_with_args_and_links)\n",
+    "Config()[\"monospace_docstrings\"] = \"True\"\n",
+    "show_doc(test_func_with_args_and_links)\n",
+    "Config()[\"monospace_docstrings\"] = \"False\""
    ]
   },
   {

--- a/settings.ini
+++ b/settings.ini
@@ -36,4 +36,5 @@ lib_path = nbdev
 tst_flags = fastai2
 custom_sidebar = False
 cell_spacing = 1
+monospace_docstrings = False
 


### PR DESCRIPTION
In our existing codebase, we like having detailed doc strings. With the current behaviour, documentation is pretty but docstrings lose their newlines/indentation, which is a problem for most of the common ways of formatting arguments. This adds a `monospace_docstrings` config option that adds `<pre>` tags around the doc strings.

![Screenshot 2020-01-07 at 12 35 20](https://user-images.githubusercontent.com/826424/71892871-69c3c500-314a-11ea-916b-10059780595a.png)
