### PR TITLE
Fix jekyll note doclinks

### DIFF
--- a/docs/export2html.html
+++ b/docs/export2html.html
@@ -319,13 +319,15 @@ summary: "The functions that transform the dev notebooks in the documentation of
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Supported styles are <code>Warning</code>, <code>Note</code> <code>Tip</code> and <code>Important</code>:</p>
 <p>Typing <code>&gt; Warning: There will be no second warning!</code> will render in the docs:
-{% include warning.html content="There will be no second warning!" %}
+{% include warning.html content='There will be no second warning!' %}
 Typing <code>&gt; Important: Pay attention! This is important.</code> will render in the docs:
-{% include important.html content="Pay attention! This is important." %}
+{% include important.html content='Pay attention! This is important.' %}
 Typing <code>&gt; Tip: This is my tip.</code> will render in the docs:
-{% include tip.html content="This is my tip." %}
+{% include tip.html content='This is my tip.' %}
 Typing <code>&gt; Note: Take note of this.</code> will render in the docs:
-{% include note.html content="Take note of this." %}</p>
+{% include note.html content='Take note of this.' %}
+Typing <code>&gt; Note: A doc link to [`add_jekyll_notes`](/export2html#add_jekyll_notes) should also work fine.</code> will render in the docs:
+{% include note.html content='A doc link to <a href="/export2html#add_jekyll_notes"><code>add_jekyll_notes</code></a> should also work fine.' %}</p>
 
 </div>
 </div>

--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -97,7 +97,7 @@ def add_jekyll_notes(cell):
     def _inner(m):
         title,text = m.groups()
         if title.lower() not in _styles: return f"> {m.groups()[0]}: {m.groups()[1]}"
-        return '{% include '+title.lower()+'.html content="'+text+'" %}'
+        return '{% include '+title.lower()+".html content=\'"+text+"\' %}"
     if cell['cell_type'] == 'markdown':
         cell['source'] = _re_block_notes.sub(_inner, cell['source'])
     return cell

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -317,7 +317,7 @@
     "    def _inner(m):\n",
     "        title,text = m.groups()\n",
     "        if title.lower() not in _styles: return f\"> {m.groups()[0]}: {m.groups()[1]}\"\n",
-    "        return '{% include '+title.lower()+'.html content=\"'+text+'\" %}'\n",
+    "        return '{% include '+title.lower()+\".html content=\\'\"+text+\"\\' %}\"\n",
     "    if cell['cell_type'] == 'markdown':\n",
     "        cell['source'] = _re_block_notes.sub(_inner, cell['source'])\n",
     "    return cell"
@@ -343,7 +343,11 @@
     "\n",
     "Typing `> Note: Take note of this.` will render in the docs:\n",
     "\n",
-    "> Note: Take note of this."
+    "> Note: Take note of this.\n",
+    "\n",
+    "Typing ``> Note: A doc link to `add_jekyll_notes` should also work fine.`` will render in the docs:\n",
+    "\n",
+    "> Note: A doc link to `add_jekyll_notes` should also work fine."
    ]
   },
   {
@@ -355,7 +359,7 @@
     "#hide\n",
     "for w in ['Warning', 'Note', 'Important', 'Tip', 'Bla']:\n",
     "    cell = {'cell_type': 'markdown', 'source': f\"> {w}: This is my final {w.lower()}!\"}\n",
-    "    res = '{% include '+w.lower()+'.html content=\"This is my final '+w.lower()+'!\" %}'\n",
+    "    res = '{% include '+w.lower()+'.html content=\\'This is my final '+w.lower()+'!\\' %}'\n",
     "    if w != 'Bla': test_eq(add_jekyll_notes(cell), {'cell_type': 'markdown', 'source': res})\n",
     "    else: test_eq(add_jekyll_notes(cell), cell)"
    ]


### PR DESCRIPTION
Changed the double quotes in the `add_jekyll_note` function by single quotes escaped (using `\`). I also updated the test case and added an example of a doc link in a Jekyll note to show that it works now.

Tested this for the nbdev docs as well as for my own docs (where I initially encountered the problem) and it seems to solve the problem in both cases.

Solves #40 