### PR TITLE
Add a warning in case some notebooks have a duplicate Title.

### DIFF
--- a/nbdev/cli.py
+++ b/nbdev/cli.py
@@ -111,6 +111,8 @@ def create_default_sidebar():
     dic = {"Overview": "/"}
     files = [f for f in Config().nbs_path.glob('*.ipynb') if not f.name.startswith('_')]
     fnames = [_nb2htmlfname(f) for f in sorted(files)]
+    titles = [_get_title(f) for f in fnames]
+    if len(titles) > len(set(titles)): print(f"Warning: Some of your Notebooks use the same title ({titles}).")
     dic.update({_get_title(f):f'/{f.stem}' for f in fnames if f.stem!='index'})
     dic = {Config().lib_name: dic}
     json.dump(dic, open(Config().doc_path/'sidebar.json', 'w'), indent=2)

--- a/nbs/06_cli.ipynb
+++ b/nbs/06_cli.ipynb
@@ -291,6 +291,8 @@
     "    dic = {\"Overview\": \"/\"}\n",
     "    files = [f for f in Config().nbs_path.glob('*.ipynb') if not f.name.startswith('_')]\n",
     "    fnames = [_nb2htmlfname(f) for f in sorted(files)]\n",
+    "    titles = [_get_title(f) for f in fnames]\n",
+    "    if len(titles) > len(set(titles)): print(f\"Warning: Some of your Notebooks use the same title ({titles}).\")\n",
     "    dic.update({_get_title(f):f'/{f.stem}' for f in fnames if f.stem!='index'})\n",
     "    dic = {Config().lib_name: dic}\n",
     "    json.dump(dic, open(Config().doc_path/'sidebar.json', 'w'), indent=2)"


### PR DESCRIPTION
Sometimes I copy a Notebook and I forget to change the title, this has caused me some confusion as to why the sidebar apparently was not generated properly. I thought it might be useful to add a simple warning if you are using the same title multiple times when generating the sidebar (as you probably never intend to do this).

Please let me know if you think this is useful, or if I should implement this in another way.