### PR TITLE
Print which file got converted to README.md in build_docs

### DIFF
--- a/nbdev/cli.py
+++ b/nbdev/cli.py
@@ -145,6 +145,7 @@ def make_readme():
     for f in Config().nbs_path.glob('*.ipynb'):
         if _re_index.match(f.name): index_fn = f
     assert index_fn is not None, "Could not locate index notebook"
+    print(f"converting {index_fn} to README.md")
     convert_md(index_fn, Config().config_file.parent, jekyll=False)
     n = Config().config_file.parent/index_fn.with_suffix('.md').name
     shutil.move(n, Config().config_file.parent/'README.md')

--- a/nbs/06_cli.ipynb
+++ b/nbs/06_cli.ipynb
@@ -362,6 +362,7 @@
     "    for f in Config().nbs_path.glob('*.ipynb'):\n",
     "        if _re_index.match(f.name): index_fn = f\n",
     "    assert index_fn is not None, \"Could not locate index notebook\"\n",
+    "    print(f\"converting {index_fn} to README.md\")\n",
     "    convert_md(index_fn, Config().config_file.parent, jekyll=False)\n",
     "    n = Config().config_file.parent/index_fn.with_suffix('.md').name\n",
     "    shutil.move(n, Config().config_file.parent/'README.md')"
@@ -754,7 +755,25 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Converted 00_export.ipynb.\n",
+      "Converted 01_sync.ipynb.\n",
+      "Converted 02_showdoc.ipynb.\n",
+      "Converted 03_export2html.ipynb.\n",
+      "Converted 04_test.ipynb.\n",
+      "Converted 05_merge.ipynb.\n",
+      "Converted 06_cli.ipynb.\n",
+      "Converted 07_clean.ipynb.\n",
+      "Converted 99_search.ipynb.\n",
+      "Converted index.ipynb.\n",
+      "Converted tutorial.ipynb.\n"
+     ]
+    }
+   ],
    "source": [
     "#hide\n",
     "from nbdev.export import *\n",


### PR DESCRIPTION
Added a print statement to note that a specific notebook is being converted to README.md (I was looking for a way to make sure readme was updated for #53). 

The only change in the behavior is the last line here: 
```
nate-macbook:~/c/nbdev chore/make_readme_print nbdev_build_docs                                                                                     (nbdev)
converting: /Users/xnutsive/code/nbdev/nbs/01_sync.ipynb
.... 
converting: /Users/xnutsive/code/nbdev/nbs/05_merge.ipynb
converting /Users/xnutsive/code/nbdev/nbs/index.ipynb to README.md
nate-macbook:~/c/nbdev chore/make_readme_print
```