### PR TITLE
Don't give a warning if the index notebook has a duplicate title

### DIFF
--- a/nbdev/cli.py
+++ b/nbdev/cli.py
@@ -112,7 +112,7 @@ def create_default_sidebar():
     dic = {"Overview": "/"}
     files = [f for f in Config().nbs_path.glob('*.ipynb') if not f.name.startswith('_')]
     fnames = [_nb2htmlfname(f) for f in sorted(files)]
-    titles = [_get_title(f) for f in fnames]
+    titles = [_get_title(f) for f in fnames if 'index' not in f.stem!='index']
     if len(titles) > len(set(titles)): print(f"Warning: Some of your Notebooks use the same title ({titles}).")
     dic.update({_get_title(f):f'/{f.stem}' for f in fnames if f.stem!='index'})
     dic = {Config().lib_name: dic}

--- a/nbs/06_cli.ipynb
+++ b/nbs/06_cli.ipynb
@@ -291,7 +291,7 @@
     "    dic = {\"Overview\": \"/\"}\n",
     "    files = [f for f in Config().nbs_path.glob('*.ipynb') if not f.name.startswith('_')]\n",
     "    fnames = [_nb2htmlfname(f) for f in sorted(files)]\n",
-    "    titles = [_get_title(f) for f in fnames]\n",
+    "    titles = [_get_title(f) for f in fnames if 'index' not in f.stem!='index']\n",
     "    if len(titles) > len(set(titles)): print(f\"Warning: Some of your Notebooks use the same title ({titles}).\")\n",
     "    dic.update({_get_title(f):f'/{f.stem}' for f in fnames if f.stem!='index'})\n",
     "    dic = {Config().lib_name: dic}\n",


### PR DESCRIPTION
Building the `fastscript` docs I realized that the `index.ipynb` can have the same title as another notebook (in this case `00_core.ipynb`) and it shouldn't give a warning. This small change should fix that.