### PR TITLE
fixes bug that _nb2htmlfname would generate 1.html from 00ab_export_module_1.ipynb

### DIFF
--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -350,7 +350,7 @@ process_cells = [remove_fake_headers, remove_hidden, remove_empty]
 process_cell  = [hide_cells, remove_widget_state, add_jekyll_notes]
 
 # Cell
-_re_digits = re.compile(r'^\d+\S*_')
+_re_digits = re.compile(r'^\d+\S*?_')
 
 # Cell
 def _nb2htmlfname(nb_path): return Config().doc_path/_re_digits.sub('', nb_path.with_suffix('.html').name)

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -1065,7 +1065,7 @@
    "outputs": [],
    "source": [
     "# export\n",
-    "_re_digits = re.compile(r'^\\d+\\S*_')"
+    "_re_digits = re.compile(r'^\\d+\\S*?_')"
    ]
   },
   {
@@ -1086,7 +1086,8 @@
    "source": [
     "#hide\n",
     "test_eq(_nb2htmlfname(Path('00a_export.ipynb')), Config().doc_path/'export.html')\n",
-    "test_eq(_nb2htmlfname(Path('export.ipynb')), Config().doc_path/'export.html')"
+    "test_eq(_nb2htmlfname(Path('export.ipynb')), Config().doc_path/'export.html')\n",
+    "test_eq(_nb2htmlfname(Path('00ab_export_module_1.ipynb')), Config().doc_path/'export_module_1.html')"
    ]
   },
   {


### PR DESCRIPTION
I found this bug when I tried to export docs from 2 notebooks named `02_gpt2_lm.ipynb` and `03_lstm_lm.ipynb`.
There is only one html file called `lm.html` be generated from those 2 notebooks.
Therefore I dig into the code in _nb2htmlfname and try to fix it.

The only thing I change is the _re_digits. 
Just add a question mark after greedy match S* and also add a test that check 00ab_export_module_1.ipynb can be transformed to export_module_1.html correctly.

Thanks.