### PR TITLE
Set min nbconvert version due to API change

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -14,7 +14,7 @@ status = 2
 min_python = 3.6
 audience = Developers
 language = English
-requirements = nbformat>=4.4.0 nbconvert pyyaml fastscript packaging
+requirements = nbformat>=4.4.0 nbconvert>=5.6.1 pyyaml fastscript packaging
 console_scripts = nbdev_build_lib=nbdev.cli:nbdev_build_lib
 	nbdev_update_lib=nbdev.cli:nbdev_update_lib
 	nbdev_diff_nbs=nbdev.cli:nbdev_diff_nbs


### PR DESCRIPTION
Fixes an issue with older versions of nbconvert - looks like prior to 5.6.1 or so - that have 'resources' as a required argument to the preprocess function, resulting in errors like this when running tests:
 `preprocess() missing 1 required positional argument: 'resources'`

Is this the only place the version would need to be updated?

nbconvert commit for the API change:
https://github.com/jupyter/nbconvert/commit/ad6d34b563d1a137a19173c149b85fc11876e2d8