### PR TITLE
Minor: fix typo in index.ipynb

### DIFF
--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -56,7 +56,7 @@
     "- the [export](http://nbdev.fast.ai/export) functionality from jupyter notebooks to a python library\n",
     "- the [cli](http://nbdev.fast.ai/cli) commands you can use with nbdev in a terminal\n",
     "- how [export2html](http://nbdev.fast.ai/export2html) builds a documentation for your library\n",
-    "- how [sync](http://nbdev.fast.ai/sync) can allow you to export back form the python modules to the jupyter notebook\n",
+    "- how [sync](http://nbdev.fast.ai/sync) can allow you to export back from the python modules to the jupyter notebook\n",
     "- how to put [tests](http://nbdev.fast.ai/test) in your notebooks, which can be run in parallel, and exported to CI from your notebooks\n",
     "- get more info about the [additional functionality](http://nbdev.fast.ai/#Additional-functionality)"
    ]


### PR DESCRIPTION
This fixes a very minor typo that jumped out at me while reading the documentation homepage: `form` -> `from`.