### PR TITLE
escape `{{` curly braces that might be in generated HTML from notebook

### DIFF
--- a/nbdev/templates/jekyll.tpl
+++ b/nbdev/templates/jekyll.tpl
@@ -10,6 +10,8 @@ sidebar: home_sidebar
 {% include 'autogen.tpl' %}
 
 <div class="container" id="notebook-container">
-    {{ super()  }}
+    {{ "{% raw %}" }}
+        {{ super()  }}
+    {{ "{% endraw %}" }}
 </div>
 {%- endblock body %}


### PR DESCRIPTION
escape `{{` curly braces that might be in HTML

I've encountered this while using this template, and this helps to guard against this situation where it may cause a problem with liquid