### PR TITLE
Revert #75

### DIFF
--- a/nbdev/templates/jekyll.tpl
+++ b/nbdev/templates/jekyll.tpl
@@ -10,8 +10,6 @@ sidebar: home_sidebar
 {% include 'autogen.tpl' %}
 
 <div class="container" id="notebook-container">
-    {{ "{% raw %}" }}
         {{ super()  }}
-    {{ "{% endraw %}" }}
 </div>
 {%- endblock body %}


### PR DESCRIPTION
Reverting changes in https://github.com/fastai/nbdev/pull/75 because while this works the way I'm using Jekyll (building myself and pushing to GitHub pages), this breaks on the version of Jekyll being used by GitHub pages.  

I suppose I need to add more tests to this repo that attempt to build a Jekyll site pinned on the version that GitHub pages uses, so I can catch this kind of error ( I tried doing this but am unable to reproduce the error locally that I get on GitHub pages even when I pin the version, but will keep trying). 

Will do further research on a safe solution, but will add more tests first to catch this error if I can figure out how to reproduce. 