### PR TITLE
fix nbdev_new when path including space

### DIFF
--- a/nbdev/cli.py
+++ b/nbdev/cli.py
@@ -306,7 +306,7 @@ def nbdev_new(name: Param("A directory to create the project in", str)):
     print(f"Creating a new nbdev project {name}.")
 
     try:
-        subprocess.run(f"git clone {_template_git_repo} {path}".split(), check=True, timeout=5000)
+        subprocess.run(['git', 'clone', f'{_template_git_repo}', f'{path}'], check=True, timeout=5000)
         shutil.rmtree(path/".git")
         subprocess.run("git init".split(), cwd=path, check=True)
         subprocess.run("git add .".split(), cwd=path, check=True)

--- a/nbs/06_cli.ipynb
+++ b/nbs/06_cli.ipynb
@@ -697,7 +697,7 @@
     "    print(f\"Creating a new nbdev project {name}.\")\n",
     "    \n",
     "    try:\n",
-    "        subprocess.run(f\"git clone {_template_git_repo} {path}\".split(), check=True, timeout=5000)\n",
+    "        subprocess.run(['git', 'clone', f'{_template_git_repo}', f'{path}'], check=True, timeout=5000)\n",
     "        shutil.rmtree(path/\".git\")\n",
     "        subprocess.run(\"git init\".split(), cwd=path, check=True)\n",
     "        subprocess.run(\"git add .\".split(), cwd=path, check=True)\n",


### PR DESCRIPTION
Bug happened when I try to use nbdev_new in the directory including space like "/gdrive/My Drive/xxx".
Fix it by not using split() at target path.