### PR TITLE
remove raw tags as they break `fastpages`

### DIFF
--- a/nbdev/templates/jekyll.tpl
+++ b/nbdev/templates/jekyll.tpl
@@ -10,8 +10,6 @@ sidebar: home_sidebar
 {% include 'autogen.tpl' %}
 
 <div class="container" id="notebook-container">
-    {{ "{% raw %}" }}
         {{ super()  }}
-    {{ "{% endraw %}" }}
 </div>
 {%- endblock body %}


### PR DESCRIPTION
There is liquid injected into fastpages notebook markdown to allow for:

- jekyll notes
- embedded youtube videos
- embedded twitter cards

So will have to find another way to escape `{{`  in notebooks with a special template that escapes code blocks only.  I will make a PR for this soon.

If you do happen to merge, this if you could please update pypi 🙇 