### PR TITLE
Improve support for pythons type hint syntax (pep 484)

### DIFF
--- a/nbs/00_export.ipynb
+++ b/nbs/00_export.ipynb
@@ -682,7 +682,7 @@
     "@patch         # At any place in the cell, something that begins with @patch\n",
     "\\s*def         # Any number of whitespace (including a new line probably) followed by def\n",
     "\\s+            # One whitespace or more\n",
-    "([^\\(\\s]*)     # Catch a group composed of anything but whitespace or an opening parenthesis (name of the function)\n",
+    "([^\\(\\s]+)     # Catch a group composed of anything but whitespace or an opening parenthesis (name of the function)\n",
     "\\s*\\(          # Any number of whitespace followed by an opening parenthesis\n",
     "[^:]*          # Any number of character different of : (the name of the first arg that is type-annotated)\n",
     ":\\s*           # A column followed by any number of whitespace\n",
@@ -713,6 +713,10 @@
     "tst = _re_patch_func.search(\"\"\"\n",
     "@patch\n",
     "def func (obj:(Class1, Class2), a)\"\"\")\n",
+    "test_eq(tst.groups(), (\"func\", None, \"(Class1, Class2)\"))\n",
+    "tst = _re_patch_func.search(\"\"\"\n",
+    "@patch\n",
+    "def func (obj:(Class1, Class2), a:int)->int:\"\"\")\n",
     "test_eq(tst.groups(), (\"func\", None, \"(Class1, Class2)\"))"
    ]
   },
@@ -725,13 +729,13 @@
     "#export\n",
     "_re_typedispatch_func = re.compile(r\"\"\"\n",
     "# Catches any function decorated with @typedispatch\n",
-    "(@typedispatch  # At any place in the cell, catch a group with something that begins with @patch\n",
+    "(@typedispatch  # At any place in the cell, catch a group with something that begins with @typedispatch\n",
     "\\s*def          # Any number of whitespace (including a new line probably) followed by def\n",
     "\\s+             # One whitespace or more\n",
-    "[^\\(]*          # Anything but whitespace or an opening parenthesis (name of the function)\n",
+    "[^\\(]+          # Anything but whitespace or an opening parenthesis (name of the function)\n",
     "\\s*\\(           # Any number of whitespace followed by an opening parenthesis\n",
     "[^\\)]*          # Any number of character different of )\n",
-    "\\)\\s*:)         # A closing parenthesis followed by whitespace and :\n",
+    "\\)[\\s\\S]*:)     # A closing parenthesis followed by any number of characters and whitespace (type annotation) and :\n",
     "\"\"\", re.VERBOSE)"
    ]
   },
@@ -742,7 +746,9 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "assert _re_typedispatch_func.search(\"@typedispatch\\ndef func(a, b):\").groups() == ('@typedispatch\\ndef func(a, b):',)"
+    "assert _re_typedispatch_func.search(\"@typedispatch\\ndef func(a, b):\").groups() == ('@typedispatch\\ndef func(a, b):',)\n",
+    "assert (_re_typedispatch_func.search(\"@typedispatch\\ndef func(a:str, b:bool)->int:\").groups() ==\n",
+    "                                    ('@typedispatch\\ndef func(a:str, b:bool)->int:',))"
    ]
   },
   {
@@ -757,7 +763,7 @@
     "^              # Beginning of a line (since re.MULTILINE is passed)\n",
     "(?:def|class)  # Non-catching group for def or class\n",
     "\\s+            # One whitespace or more\n",
-    "([^\\(\\s]*)     # Catching group with any character except an opening parenthesis or a whitespace (name)\n",
+    "([^\\(\\s]+)     # Catching group with any character except an opening parenthesis or a whitespace (name)\n",
     "\\s*            # Any number of whitespace\n",
     "(?:\\(|:)       # Non-catching group with either an opening parenthesis or a : (classes don't need ())\n",
     "\"\"\", re.MULTILINE | re.VERBOSE)"
@@ -771,7 +777,8 @@
    "source": [
     "#hide\n",
     "test_eq(_re_class_func_def.search(\"class Class:\").groups(), ('Class',))\n",
-    "test_eq(_re_class_func_def.search(\"def func(a, b):\").groups(), ('func',))"
+    "test_eq(_re_class_func_def.search(\"def func(a, b):\").groups(), ('func',))\n",
+    "test_eq(_re_class_func_def.search(\"def func(a:str, b:bool)->int:\").groups(), ('func',))"
    ]
   },
   {
@@ -783,9 +790,10 @@
     "#export\n",
     "_re_obj_def = re.compile(r\"\"\"\n",
     "# Catches any 0-indented object definition (bla = thing) with its name in group 1\n",
-    "^          # Beginning of a line (since re.MULTILINE is passed)\n",
-    "([^=\\s]*)  # Catching group with any character except a whitespace or an equal sign\n",
-    "\\s*=       # Any number of whitespace followed by an =\n",
+    "^                          # Beginning of a line (since re.MULTILINE is passed)\n",
+    "([_a-zA-Z]+[a-zA-Z0-9_\\.]*)  # Catch a group which is a valid python variable name\n",
+    "\\s*                        # Any number of whitespace\n",
+    "(?::\\s*\\S.*|)=  # Non-catching group of either a colon followed by a type annotation, or nothing; followed by an =\n",
     "\"\"\", re.MULTILINE | re.VERBOSE)"
    ]
   },
@@ -797,7 +805,12 @@
    "source": [
     "#hide\n",
     "test_eq(_re_obj_def.search(\"a = 1\").groups(), ('a',))\n",
-    "test_eq(_re_obj_def.search(\"a=1\").groups(), ('a',))"
+    "test_eq(_re_obj_def.search(\"a.b = 1\").groups(), ('a.b',))\n",
+    "test_eq(_re_obj_def.search(\"_aA1=1\").groups(), ('_aA1',))\n",
+    "test_eq(_re_obj_def.search(\"a : int =1\").groups(), ('a',))\n",
+    "test_eq(_re_obj_def.search(\"a:f(':=')=1\").groups(), ('a',))\n",
+    "assert _re_obj_def.search(\"@abc=2\") is None\n",
+    "assert _re_obj_def.search(\"a a=2\") is None"
    ]
   },
   {
@@ -1095,31 +1108,6 @@
    "metadata": {},
    "source": [
     "To be able to build back a correspondence between functions and the notebooks they are defined in, we need to store an index. It's done in the private module <code>_nbdev</code> inside your library, and the following function are used to define it."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#export\n",
-    "_re_patch_func = re.compile(r\"\"\"\n",
-    "# Catches any function decorated with @patch, its name in group 1 and the patched class in group 2\n",
-    "@patch         # At any place in the cell, something that begins with @patch\n",
-    "\\s*def         # Any number of whitespace (including a new line probably) followed by def\n",
-    "\\s+            # One whitespace or more\n",
-    "([^\\(\\s]*)     # Catch a group composed of anything but whitespace or an opening parenthesis (name of the function)\n",
-    "\\s*\\(          # Any number of whitespace followed by an opening parenthesis\n",
-    "[^:]*          # Any number of character different of : (the name of the first arg that is type-annotated)\n",
-    ":\\s*           # A column followed by any number of whitespace\n",
-    "(?:            # Non-catching group with either\n",
-    "([^,\\s\\(\\)]*)  #    a group composed of anything but a comma, a parenthesis or whitespace (name of the class)\n",
-    "|              #  or\n",
-    "(\\([^\\)]*\\)))  #    a group composed of something between parenthesis (tuple of classes)\n",
-    "\\s*            # Any number of whitespace\n",
-    "(?:,|\\))       # Non-catching group with either a comma or a closing parenthesis\n",
-    "\"\"\", re.VERBOSE)"
    ]
   },
   {


### PR DESCRIPTION
Hi again,
I'm working a lot with ctypes at the moment, which is why it's much easier in the long run to write code where most things have type annotations on them.
I've noticed however, that when I declare a global variable with a type hint e.g. `a:int = 1`, the name that's added to `__all__` is not `'a'` as one might expect, but `'a:int'`.
This causes any code that is trying to import that module to crash, because `'a:int'` is not valid python syntax for a variable name.

This PR is fixing this particular case, and a few other things I spotted along the way.

I hope this will be useful to people.

Here is a __changelog__ of everything that's changed. All changes were made in `nbs/00_export.ipynb`:

- Add a test case to `_re_patch_func` to check that type annotations, including return types, are handled correctly.

- Change `_re_patch_func` to require that there is at least one character used as a function name. Previously `def (...)` would also match.

- Delete repeated and identical declaration of `_re_patch_func`.

- Add support for return type annotations to `_re_typedispatch_func`. Previously a function that had a return type specified using the arrow notation `def ... (...) -> type:` would not match.

- Change `_re_typedispatch_func` to require there to be at least one character used as a name. Previously `def (...)` would also match.

- Changed `_re_typedispatch_func` documentation to reflect the changes above, and correct a copy-paste artifact.

- Add a test case to `_re_typedispatch_func` to check that return types are handled correctly.

- Change `_re_class_func_def` to require there to be at least one character used as a name. Previously `def (...)` would also match.

- Add test case to `_re_class_func_def` to check that type annotations are handled correctly.

- Change `_re_obj_def` to correctly distinguish type information from the variable name. Previously `a:int = 1` would match as `a:int`, which is not correct. Also variable names will now only match if they are a legal python name. Previously e.g. `@-@./! = 1` would match as `@-@./!` and `@dec(a=1)` would match as `@dec(a`, which could be a problem when dealing with decorators (although the decorator case is caught by a later check, this is in my opinion still the cleaner way).

- Change documentation of `_re_obj_def` to make clear how this new code works.

- Add test cases to `_re_obj_def` that check for some of the edge cases mentioned above.

For more info on pythons type hints view https://www.python.org/dev/peps/pep-0484/