### PR TITLE
remove anchor tag text

### DIFF
--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -364,6 +364,7 @@ def nbdev_exporter(cls=HTMLExporter, template_file=None):
     exporter = cls(cfg)
     exporter.exclude_input_prompt=True
     exporter.exclude_output_prompt=True
+    exporter.anchor_link_text = ''
     exporter.template_file = 'jekyll.tpl' if template_file is None else template_file
     exporter.template_path.append(str(Path(__file__).parent/'templates'))
     return exporter

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -1182,6 +1182,7 @@
     "    exporter = cls(cfg)\n",
     "    exporter.exclude_input_prompt=True\n",
     "    exporter.exclude_output_prompt=True\n",
+    "    exporter.anchor_link_text = ''\n",
     "    exporter.template_file = 'jekyll.tpl' if template_file is None else template_file\n",
     "    exporter.template_path.append(str(Path(__file__).parent/'templates'))\n",
     "    return exporter"


### PR DESCRIPTION
# Background

- nbconvert injects the ugly ¶ symbol as text in anchor tags.
- nbdev ignores the ¶ using CSS by [setting display value to none](https://github.com/fastai/nbdev/blob/c41b7e6b85ae452fb1d9eeb5fe7077275eb0c1ef/docs/css/customstyles.css#L1-L3) and uses anchor.js to apply beautiful styling. 
- However, these ugly ¶ show up in fastpages, and I'm using javascript to remove them.  This seems like the best way to remove this text.   It is useful to remove this text b/c it shows up in search results.

cc: @sgugger