### PR TITLE
Fix #101

### DIFF
--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -364,7 +364,7 @@ def nbdev_exporter(cls=HTMLExporter, template_file=None):
     exporter = cls(cfg)
     exporter.exclude_input_prompt=True
     exporter.exclude_output_prompt=True
-    exporter.anchor_link_text = ''
+    exporter.anchor_link_text = ' '
     exporter.template_file = 'jekyll.tpl' if template_file is None else template_file
     exporter.template_path.append(str(Path(__file__).parent/'templates'))
     return exporter

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -1182,7 +1182,7 @@
     "    exporter = cls(cfg)\n",
     "    exporter.exclude_input_prompt=True\n",
     "    exporter.exclude_output_prompt=True\n",
-    "    exporter.anchor_link_text = ''\n",
+    "    exporter.anchor_link_text = ' '\n",
     "    exporter.template_file = 'jekyll.tpl' if template_file is None else template_file\n",
     "    exporter.template_path.append(str(Path(__file__).parent/'templates'))\n",
     "    return exporter"


### PR DESCRIPTION
Fix what seems to be breakage after #101, just adding " " (space) instead of empty string to exporter.anchor_link_text. 

With an empty string the html generates self closing "a" tags. When inside of a header (which happens in every header with nbdev) it expects a following opening tag but instead gets a closing one. This makes it so that you can't see text until you add a new link, whenever that may be. Don't quite understand why this happens though. 

Html seems to ignore the extra whiteline so you can't see it, it doens't even indent text.

Images of before and after: 

![Screenshot_20200302_195154](https://user-images.githubusercontent.com/60252434/75735412-3ae84c00-5cc0-11ea-886b-644ce3bd869c.png) 

After

![Screenshot_20200302_195417](https://user-images.githubusercontent.com/60252434/75735416-3b80e280-5cc0-11ea-9be9-d6f44e5ddeaf.png)