### PR TITLE
Change Linux specific check to also work on other platforms

### DIFF
--- a/nbdev/imports.py
+++ b/nbdev/imports.py
@@ -37,7 +37,7 @@ class Config:
     "Store the basic information for nbdev to work"
     def __init__(self, cfg_name='settings.ini'):
         cfg_path = Path.cwd()
-        while cfg_path != Path('/') and not (cfg_path/cfg_name).exists(): cfg_path = cfg_path.parent
+        while cfg_path != cfg_path.parent and not (cfg_path/cfg_name).exists(): cfg_path = cfg_path.parent
         self.config_file = cfg_path/cfg_name
         assert self.config_file.exists(), "Use `create_config` to create settings.ini for the first time"
         self.d = read_config_file(self.config_file)['DEFAULT']


### PR DESCRIPTION
On windows the root of the file tree is a drive letter (e.g. `'C:/'`), meaning the `cfg_path != Path('/')` check can never be false, causing an infinite loop when no settings.ini exists.