### PR TITLE
fix liquid tags only one curly brace

### DIFF
--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -191,7 +191,7 @@ _re_latex = re.compile(r'^(\$\$.*\$\$)$', re.MULTILINE)
 # Cell
 def escape_latex(cell):
     if cell['cell_type'] != 'markdown': return cell
-    cell['source'] = _re_latex.sub(r'{{% raw %}}\n\1\n{{% endraw %}}', cell['source'])
+    cell['source'] = _re_latex.sub(r'{% raw %}\n\1\n{% endraw %}', cell['source'])
     return cell
 
 # Cell

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -644,7 +644,7 @@
     "#export\n",
     "def escape_latex(cell):\n",
     "    if cell['cell_type'] != 'markdown': return cell\n",
-    "    cell['source'] = _re_latex.sub(r'{{% raw %}}\\n\\1\\n{{% endraw %}}', cell['source'])\n",
+    "    cell['source'] = _re_latex.sub(r'{% raw %}\\n\\1\\n{% endraw %}', cell['source'])\n",
     "    return cell"
    ]
   },
@@ -657,7 +657,7 @@
     "cell = {'cell_type': 'markdown', \n",
     "        'source': 'lala\\n$$equation$$\\nlala'}\n",
     "cell = escape_latex(cell)\n",
-    "test_eq(cell['source'], 'lala\\n{{% raw %}}\\n$$equation$$\\n{{% endraw %}}\\nlala')"
+    "test_eq(cell['source'], 'lala\\n{% raw %}\\n$$equation$$\\n{% endraw %}\\nlala')"
    ]
   },
   {


### PR DESCRIPTION
You accidentally used `{{% raw %}}` instead of `{% raw %} `

See https://shopify.github.io/liquid/tags/raw/

I pulled my hair out for hours trying to figure out what was going wrong.  Luckily I finally was able to "see" the double curly braces!  Wooo 🙇 

@sgugger do you mind cutting another release?  