### PR TITLE
Fixed #hide_output and added #collapse_output flag

### DIFF
--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -49,10 +49,14 @@ def remove_widget_state(cell):
 # Matches any cell that has a `show_doc` or an `#export` in it
 _re_cell_to_hide = r's*show_doc\(|^\s*#\s*export\s+|^\s*#\s*hide_input\s+'
 
+# Matches any cell with `#hide_output` or `#hide_output`
+_re_hide_output = r'^\s*#\s*hide-output\s+|^\s*#\s*hide_output\s+'
+
 # Cell
 def hide_cells(cell):
     "Hide inputs of `cell` that need to be hidden"
     if check_re(cell, _re_cell_to_hide):  cell['metadata'] = {'hide_input': True}
+    elif check_re(cell, _re_hide_output):  cell['metadata'] = {'hide_output': True}
     return cell
 
 # Cell

--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -205,11 +205,15 @@ _re_cell_to_collapse_closed = re.compile(r'^\s*#\s*(collapse|collapse_hide|colla
 #Matches any cell with #collapse_show
 _re_cell_to_collapse_open = re.compile(r'^\s*#\s*(collapse_show|collapse-show)\s+')
 
+#Matches any cell with #collapse_output or #collapse-output
+_re_cell_to_collapse_output = re.compile(r'^\s*#\s*(collapse_output|collapse-output)\s+')
+
 # Cell
 def collapse_cells(cell):
     "Add a collapse button to inputs of `cell` in either the open or closed position"
     if check_re(cell, _re_cell_to_collapse_closed):  cell['metadata'] = {'collapse_hide': True}
     elif check_re(cell, _re_cell_to_collapse_open):  cell['metadata'] = {'collapse_show': True}
+    elif check_re(cell, _re_cell_to_collapse_output):  cell['metadata'] = {'collapse_output': True}
     return cell
 
 # Cell

--- a/nbdev/templates/hide.tpl
+++ b/nbdev/templates/hide.tpl
@@ -26,6 +26,12 @@
 
 {% block output_group -%}
 {%- if cell.metadata.hide_output -%}
+{%- elif cell.metadata.collapse_output -%}
+    <details class="description">
+      <summary data-open="Hide Output" data-close="Show Output"></summary>
+        <summary></summary>
+        {{ super() }}
+    </details>
 {%- else -%}
     {{ super()  }}
 {%- endif -%}

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -706,7 +706,10 @@
     "_re_cell_to_collapse_closed = re.compile(r'^\\s*#\\s*(collapse|collapse_hide|collapse-hide)\\s+')\n",
     "\n",
     "#Matches any cell with #collapse_show\n",
-    "_re_cell_to_collapse_open = re.compile(r'^\\s*#\\s*(collapse_show|collapse-show)\\s+')"
+    "_re_cell_to_collapse_open = re.compile(r'^\\s*#\\s*(collapse_show|collapse-show)\\s+')\n",
+    "\n",
+    "#Matches any cell with #collapse_output or #collapse-output\n",
+    "_re_cell_to_collapse_output = re.compile(r'^\\s*#\\s*(collapse_output|collapse-output)\\s+')"
    ]
   },
   {
@@ -720,6 +723,7 @@
     "    \"Add a collapse button to inputs of `cell` in either the open or closed position\"\n",
     "    if check_re(cell, _re_cell_to_collapse_closed):  cell['metadata'] = {'collapse_hide': True}\n",
     "    elif check_re(cell, _re_cell_to_collapse_open):  cell['metadata'] = {'collapse_show': True}\n",
+    "    elif check_re(cell, _re_cell_to_collapse_output):  cell['metadata'] = {'collapse_output': True}\n",
     "    return cell"
    ]
   },
@@ -774,6 +778,31 @@
    "source": [
     "#collapse\n",
     "print('The code cell that produced this output is collapsed by default but you can expand it!')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- Placing `#collapse_output` as a comment in code cell will hide the output under a collapsable element that is **closed** by default."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The input of this cell is visible as usual.  However, the OUTPUT of this cell is collapsed by default but you can expand it!\n"
+     ]
+    }
+   ],
+   "source": [
+    "#collapse-output\n",
+    "print('The input of this cell is visible as usual.  However, the OUTPUT of this cell is collapsed by default but you can expand it!')"
    ]
   },
   {
@@ -1495,18 +1524,15 @@
      "output_type": "stream",
      "text": [
       "converting: 01_sync.ipynb\n",
-      "converting: /home/jovyan/nbdev/nbs/99_search.ipynb\n",
-      "converting: /home/jovyan/nbdev/nbs/06_cli.ipynb\n",
       "converting: /home/jovyan/nbdev/nbs/04_test.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/06_cli.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/99_search.ipynb\n",
       "converting: /home/jovyan/nbdev/nbs/03_export2html.ipynb\n",
-      "converting: /home/jovyan/nbdev/nbs/12_hamel_test_notebook.ipynb\n",
-      "converting: /home/jovyan/nbdev/nbs/13_estimating_infected.ipynb\n",
       "converting: /home/jovyan/nbdev/nbs/01_sync.ipynb\n",
-      "converting: /home/jovyan/nbdev/nbs/Image-Test.ipynb\n",
       "converting: /home/jovyan/nbdev/nbs/00_export.ipynb\n",
       "converting: /home/jovyan/nbdev/nbs/02_showdoc.ipynb\n",
-      "converting: /home/jovyan/nbdev/nbs/07_clean.ipynb\n",
       "converting: /home/jovyan/nbdev/nbs/index.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/07_clean.ipynb\n",
       "converting: /home/jovyan/nbdev/nbs/tutorial.ipynb\n",
       "converting: /home/jovyan/nbdev/nbs/05_merge.ipynb\n",
       "converting: ../README.md\n",

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -164,7 +164,10 @@
    "source": [
     "#export\n",
     "# Matches any cell that has a `show_doc` or an `#export` in it\n",
-    "_re_cell_to_hide = r's*show_doc\\(|^\\s*#\\s*export\\s+|^\\s*#\\s*hide_input\\s+'"
+    "_re_cell_to_hide = r's*show_doc\\(|^\\s*#\\s*export\\s+|^\\s*#\\s*hide_input\\s+'\n",
+    "\n",
+    "# Matches any cell with `#hide_output` or `#hide_output`\n",
+    "_re_hide_output = r'^\\s*#\\s*hide-output\\s+|^\\s*#\\s*hide_output\\s+'"
    ]
   },
   {
@@ -177,6 +180,7 @@
     "def hide_cells(cell):\n",
     "    \"Hide inputs of `cell` that need to be hidden\"\n",
     "    if check_re(cell, _re_cell_to_hide):  cell['metadata'] = {'hide_input': True}\n",
+    "    elif check_re(cell, _re_hide_output):  cell['metadata'] = {'hide_output': True}\n",
     "    return cell"
    ]
   },
@@ -199,8 +203,32 @@
     "    assert 'metadata' in cell1\n",
     "    assert 'hide_input' in cell1['metadata']\n",
     "    assert cell1['metadata']['hide_input']\n",
-    "\n",
+    "    \n",
     "cell = {'cell_type': 'code', 'source': '# exports\\nfrom local.core import *'}\n",
+    "test_eq(hide_cells(cell.copy()), cell)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This concerns all the cells with a `#hide_output` or `#hide-output` flag."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for source in ['# hide-output\\nfrom local.core import *', '# hide_output\\n2+2']:\n",
+    "    cell = {'cell_type': 'code', 'source': source}\n",
+    "    cell1 = hide_cells(cell.copy())\n",
+    "    assert 'metadata' in cell1\n",
+    "    assert 'hide_output' in cell1['metadata']\n",
+    "    assert cell1['metadata']['hide_output']\n",
+    "\n",
+    "cell = {'cell_type': 'code', 'source': '# hide-outputs\\nfrom local.core import *'}\n",
     "test_eq(hide_cells(cell.copy()), cell)"
    ]
   },
@@ -1467,17 +1495,20 @@
      "output_type": "stream",
      "text": [
       "converting: 01_sync.ipynb\n",
-      "converting: /home/old-ufo/dev/nbdev/nbs/06_cli.ipynb\n",
-      "converting: /home/old-ufo/dev/nbdev/nbs/index.ipynb\n",
-      "converting: /home/old-ufo/dev/nbdev/nbs/05_merge.ipynb\n",
-      "converting: /home/old-ufo/dev/nbdev/nbs/99_search.ipynb\n",
-      "converting: /home/old-ufo/dev/nbdev/nbs/07_clean.ipynb\n",
-      "converting: /home/old-ufo/dev/nbdev/nbs/tutorial.ipynb\n",
-      "converting: /home/old-ufo/dev/nbdev/nbs/02_showdoc.ipynb\n",
-      "converting: /home/old-ufo/dev/nbdev/nbs/03_export2html.ipynb\n",
-      "converting: /home/old-ufo/dev/nbdev/nbs/00_export.ipynb\n",
-      "converting: /home/old-ufo/dev/nbdev/nbs/04_test.ipynb\n",
-      "converting: /home/old-ufo/dev/nbdev/nbs/01_sync.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/99_search.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/06_cli.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/04_test.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/03_export2html.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/12_hamel_test_notebook.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/13_estimating_infected.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/01_sync.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/Image-Test.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/00_export.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/02_showdoc.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/07_clean.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/index.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/tutorial.ipynb\n",
+      "converting: /home/jovyan/nbdev/nbs/05_merge.ipynb\n",
       "converting: ../README.md\n",
       "Notebook does not appear to be JSON: '![](https://github.com/fastai/nbdev/wor...\n"
      ]
@@ -1833,7 +1864,10 @@
       "Converted 05_merge.ipynb.\n",
       "Converted 06_cli.ipynb.\n",
       "Converted 07_clean.ipynb.\n",
+      "Converted 12_hamel_test_notebook.ipynb.\n",
+      "Converted 13_estimating_infected.ipynb.\n",
       "Converted 99_search.ipynb.\n",
+      "Converted Image-Test.ipynb.\n",
       "Converted index.ipynb.\n",
       "Converted tutorial.ipynb.\n"
      ]
@@ -1843,13 +1877,6 @@
     "#hide\n",
     "notebook2script()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -1864,10 +1864,7 @@
       "Converted 05_merge.ipynb.\n",
       "Converted 06_cli.ipynb.\n",
       "Converted 07_clean.ipynb.\n",
-      "Converted 12_hamel_test_notebook.ipynb.\n",
-      "Converted 13_estimating_infected.ipynb.\n",
       "Converted 99_search.ipynb.\n",
-      "Converted Image-Test.ipynb.\n",
       "Converted index.ipynb.\n",
       "Converted tutorial.ipynb.\n"
      ]


### PR DESCRIPTION
cc: @sgugger 

- Fixed `#hide_output` flag, the scaffolding was there but wasn't being implemented AFAIK?
- Added `#collapse_output` flag, with documentation.  Alias is `#collapse-output`

This PR closes https://github.com/fastai/nbdev_template/issues/12