### PR TITLE
Local Jekyll rendering incorrectly with extra `/`

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -57,6 +57,6 @@ defaults:
 
 sidebars: [home_sidebar]
 permalink: pretty
-baseurl: /
+baseurl: 
 #theme: jekyll-theme-cayman
 


### PR DESCRIPTION
Removing ending "/" for correct URL
 #Related Issue
#126 Local Jekyll rendering incorrectly with extra `/`