### PR TITLE
_script2notebook: assertion wrongly reports '0' for expected number of cells

### DIFF
--- a/nbs/01_sync.ipynb
+++ b/nbs/01_sync.ipynb
@@ -334,7 +334,7 @@
     "    splits = _split(code)\n",
     "    rel_name = fname.absolute().resolve().relative_to(Config().lib_path)\n",
     "    key = str(rel_name.with_suffix(''))\n",
-    "    assert len(splits)==len(dic[key]), f\"Exported file from notebooks should have {len(dic[fname])} cells but has {len(splits)}.\"\n",
+    "    assert len(splits)==len(dic[key]), f\"Exported file from notebooks should have {len(dic[key])} cells but has {len(splits)}.\"\n",
     "    assert all([c1[0]==c2[1]] for c1,c2 in zip(splits, dic[key]))\n",
     "    splits = [(c2[0],c1[0],c1[1]) for c1,c2 in zip(splits, dic[key])]\n",
     "    nb_fnames = {Config().nbs_path/s[1] for s in splits}\n",


### PR DESCRIPTION
in
`assert len(splits)==len(dic[key]), f\"Exported file from notebooks should have {len(dic[fname])} cells but has {len(splits)}.\"`
what's checked is `len(dic[key])` but what's reported in assertion failure message is `len(dic[fname])`. since `dic` is
a defaultdict, it's just happy to output the incorrect `0`