### PR TITLE
fix issue #156

### DIFF
--- a/nbdev/templates/hide-md.tpl
+++ b/nbdev/templates/hide-md.tpl
@@ -1,0 +1,33 @@
+{%- extends 'markdown.tpl' -%}
+
+{% block input_group -%}
+{%- if cell.metadata.collapse_show -%}
+<details class="description" open>
+    <summary>Code details ...</summary>
+    {{ super() }}
+</details>
+{{ '' }}
+{%- elif cell.metadata.collapse_hide -%}
+<details class="description">
+    <summary>Code details ...</summary>
+    {{ super() }}
+</details>
+{{ '' }}
+{%- elif cell.metadata.hide_input or nb.metadata.hide_input -%}
+{%- else -%}
+    {{ super() }}
+{%- endif -%}
+{% endblock input_group %}
+
+{% block output_group -%}
+{%- if cell.metadata.hide_output -%}
+{%- elif cell.metadata.collapse_output -%}
+<details class="description">
+    <summary>Output details ...</summary>
+    {{ super() }}
+</details>
+{{ '' }}
+{%- else -%}
+    {{ super() }}
+{%- endif -%}
+{% endblock output_group %}

--- a/nbdev/templates/jekyll-md.tpl
+++ b/nbdev/templates/jekyll-md.tpl
@@ -1,4 +1,4 @@
-{%- extends 'markdown.tpl' -%}{% block body %}---
+{%- extends 'hide-md.tpl' -%}{% block body %}---
 {% if resources.title != "" and resources.title != nil %}title: {{resources.title}}{% endif %}
 {% if resources.author != "" and resources.author != nil %}author: {{resources.author}}{% endif %}
 {% if resources.date != "" and resources.date != nil %}date: {{resources.date}}{% endif %}

--- a/nbdev/templates/md.tpl
+++ b/nbdev/templates/md.tpl
@@ -1,4 +1,4 @@
-{%- extends 'markdown.tpl' -%}{% block body %}
+{%- extends 'hide-md.tpl' -%}{% block body %}
 {% if resources.title != "" and resources.title != nil %}# {{resources.title}}{% endif %}
 {% if resources.summary != "" and resources.summary != nil %}> {{resources.summary}}{% endif %}
 


### PR DESCRIPTION
some details that might help review
- hide-md.tpl is a copy of hide.tpl - with a few differences
    - the zero indent of the `details` tags is important - they won't render properly if we indent like in hide.tpl
    - we need {{ '' }} after </details> or the next part (usually some output) is not rendered correctly
    - I removed the `{% block output_area_prompt %}` section - as this comes from basic.tpl
    - I removed the `{% block codecell %}` section - this caused "{% raw %}" to be rendered in the md
