### PR TITLE
Create binder tags for PRs

### DIFF
--- a/.github/workflows/binder.yaml
+++ b/.github/workflows/binder.yaml
@@ -1,0 +1,29 @@
+name: Binder
+on: 
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  Create-Binder-Badge:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: checkout pull request branch
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: comment on PR with Binder link
+      uses: actions/github-script@v1
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          var BRANCH_NAME = process.env.BRANCH_NAME;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${context.repo.owner}/${context.repo.repo}/${BRANCH_NAME}) :point_left: Launch a binder notebook on this branch`
+          }) 
+      env:
+        BRANCH_NAME: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
[mybinder.org](https://mybinder.org/) is a free service maintained by the Jupyter community that allows you to serve Jupyter Notebooks with the right dependencies for free.  Furthermore, dependencies can be targeted on a branch or a pull request.   

This Action will drop this badge on all PRs which is a link to view a notebook on the branch of the PR, which will have dependencies preinstalled according to whatever is in `environment.yml`.  The Action will make a comment that looks like this:

![image](https://user-images.githubusercontent.com/1483922/82501774-ab765c00-9aaa-11ea-8373-26c0aa71ce44.png)

@sgugger let me know if this is something you are interested in.  I have found it very helpful for my projects.  cc: @betatim