### PR TITLE
add option to use custom git template

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Now, run `jupyter notebook`, and click `00_core.ipynb`. This is where you'll cre
 
 In the last cell of your notebook, you can then run:
 
-```python
+```
 from nbdev.export import *
 notebook2script()
 ```

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -762,7 +762,7 @@ description: "Console commands added by the nbdev library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="nbdev_new" class="doc_header"><code>nbdev_new</code><a href="https://github.com/fastai/nbdev/tree/master/nbdev/cli.py#L342" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>nbdev_new</code>(<strong><code>name</code></strong>:"A directory to create the project in")</p>
+<h4 id="nbdev_new" class="doc_header"><code>nbdev_new</code><a href="https://github.com/fastai/nbdev/tree/master/nbdev/cli.py#L342" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>nbdev_new</code>(<strong><code>name</code></strong>:"A directory to create the project in", <strong><code>template_git_repo</code></strong>:"url to template repo"=<em><code>'https://github.com/fastai/nbdev_template.git'</code></em>)</p>
 </blockquote>
 <p>Create a new nbdev project with a given name.</p>
 
@@ -778,7 +778,7 @@ description: "Console commands added by the nbdev library"
 
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p><a href="/cli#nbdev_new"><code>nbdev_new</code></a> is a command line tool that creates a new nbdev project based on the <a href="https://github.com/fastai/nbdev_template">nbdev_template repo</a>. It'll initialize a new git repository and commit the new project.</p>
+<p><a href="/cli#nbdev_new"><code>nbdev_new</code></a> is a command line tool that creates a new nbdev project based on the <a href="https://github.com/fastai/nbdev_template">nbdev_template repo</a>. You can use a custom template by passing in <code>template_git_repo</code>. It'll initialize a new git repository and commit the new project.</p>
 <p>After you run <a href="/cli#nbdev_new"><code>nbdev_new</code></a>, please edit <code>settings.ini</code> and run <a href="/cli#nbdev_build_lib"><code>nbdev_build_lib</code></a>.</p>
 
 </div>

--- a/nbdev/cli.py
+++ b/nbdev/cli.py
@@ -358,7 +358,7 @@ def nbdev_new(name: Param("A directory to create the project in", str),
         func(path)
 
     try:
-        subprocess.run(['git', 'clone', f'{_template_git_repo}', f'{path}'], check=True, timeout=5000)
+        subprocess.run(['git', 'clone', f'{template_git_repo}', f'{path}'], check=True, timeout=5000)
         # Note: on windows, .git is created with a read-only flag
         shutil.rmtree(path/".git", onerror=rmtree_onerror)
         subprocess.run("git init".split(), cwd=path, check=True)

--- a/nbdev/cli.py
+++ b/nbdev/cli.py
@@ -340,7 +340,8 @@ _template_git_repo = "https://github.com/fastai/nbdev_template.git"
 
 # Cell
 @call_parse
-def nbdev_new(name: Param("A directory to create the project in", str)):
+def nbdev_new(name: Param("A directory to create the project in", str),
+              template_git_repo: Param("url to template repo", str)=_template_git_repo):
     "Create a new nbdev project with a given name."
 
     path = Path(f"./{name}").absolute()

--- a/nbs/06_cli.ipynb
+++ b/nbs/06_cli.ipynb
@@ -906,7 +906,7 @@
     "        func(path)\n",
     "    \n",
     "    try:\n",
-    "        subprocess.run(['git', 'clone', f'{_template_git_repo}', f'{path}'], check=True, timeout=5000)\n",
+    "        subprocess.run(['git', 'clone', f'{template_git_repo}', f'{path}'], check=True, timeout=5000)\n",
     "        # Note: on windows, .git is created with a read-only flag \n",
     "        shutil.rmtree(path/\".git\", onerror=rmtree_onerror)\n",
     "        subprocess.run(\"git init\".split(), cwd=path, check=True)\n",

--- a/nbs/06_cli.ipynb
+++ b/nbs/06_cli.ipynb
@@ -888,7 +888,8 @@
    "source": [
     "#export\n",
     "@call_parse\n",
-    "def nbdev_new(name: Param(\"A directory to create the project in\", str)):\n",
+    "def nbdev_new(name: Param(\"A directory to create the project in\", str),\n",
+    "              template_git_repo: Param(\"url to template repo\", str)=_template_git_repo):\n",
     "    \"Create a new nbdev project with a given name.\"\n",
     "    \n",
     "    path = Path(f\"./{name}\").absolute()\n",
@@ -928,7 +929,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`nbdev_new` is a command line tool that creates a new nbdev project based on the [nbdev_template repo](https://github.com/fastai/nbdev_template). It'll initialize a new git repository and commit the new project.\n",
+    "`nbdev_new` is a command line tool that creates a new nbdev project based on the [nbdev_template repo](https://github.com/fastai/nbdev_template). You can use a custom template by passing in `template_git_repo`. It'll initialize a new git repository and commit the new project.\n",
     "\n",
     "After you run `nbdev_new`, please edit `settings.ini` and run `nbdev_build_lib`."
    ]
@@ -989,5 +990,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Enable option to pass in custom git template repository url by setting `--template_git_repo`. 

```
usage: nbdev_new [-h] [--template_git_repo TEMPLATE_GIT_REPO] [--xtra XTRA] name

Create a new nbdev project with a given name.

positional arguments:
  name                  A directory to create the project in

optional arguments:
  -h, --help            show this help message and exit
  --template_git_repo TEMPLATE_GIT_REPO
                        url to template repo (default: https://github.com/fastai/nbdev_template.git)
  --xtra XTRA           Parse for additional args
```