### PR TITLE
added tags to cell_metadata_keep

### DIFF
--- a/nbdev/clean.py
+++ b/nbdev/clean.py
@@ -21,7 +21,7 @@ def clean_cell_output(cell):
         for o in cell['outputs']: rm_execution_count(o)
 
 # Cell
-cell_metadata_keep = ["hide_input"]
+cell_metadata_keep = ["hide_input", "tags"]
 nb_metadata_keep   = ["kernelspec", "jekyll", "jupytext", "doc"]
 
 # Cell

--- a/nbs/07_clean.ipynb
+++ b/nbs/07_clean.ipynb
@@ -100,7 +100,7 @@
    "outputs": [],
    "source": [
     "%nbdev_export\n",
-    "cell_metadata_keep = [\"hide_input\"]\n",
+    "cell_metadata_keep = [\"hide_input\", \"tags\"]\n",
     "nb_metadata_keep   = [\"kernelspec\", \"jekyll\", \"jupytext\", \"doc\"]"
    ]
   },


### PR DESCRIPTION
This is to allow the usages of tags in notebooks to also be in the repo when using the nbdev githooks.