### PR TITLE
Stricter pattern matching for imports

### DIFF
--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -412,7 +412,7 @@ def _gather_export_mods(cells):
 # match any cell containing a zero indented import from the current lib
 _re_lib_import = ReLibName(r"^from LIB_NAME\.", re.MULTILINE)
 # match any cell containing a zero indented import
-_re_import = re.compile(r"^from[ \t]|^import[ \t]", re.MULTILINE)
+_re_import = re.compile(r"^from[ \t]+\S+[ \t]+import|^import[ \t]", re.MULTILINE)
 # match any cell containing a zero indented call to notebook2script
 _re_notebook2script = re.compile(r"^notebook2script\(", re.MULTILINE)
 

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -1437,7 +1437,7 @@
     "# match any cell containing a zero indented import from the current lib\n",
     "_re_lib_import = ReLibName(r\"^from LIB_NAME\\.\", re.MULTILINE)\n",
     "# match any cell containing a zero indented import\n",
-    "_re_import = re.compile(r\"^from[ \\t]|^import[ \\t]\", re.MULTILINE)\n",
+    "_re_import = re.compile(r\"^from[ \\t]+\\S+[ \\t]+import|^import[ \\t]\", re.MULTILINE)\n",
     "# match any cell containing a zero indented call to notebook2script\n",
     "_re_notebook2script = re.compile(r\"^notebook2script\\(\", re.MULTILINE)"
    ]
@@ -1483,7 +1483,8 @@
     "    (False,'class Ex(ExP):\\n\"An `ExP` that ...\"\\ndef preprocess_cell(self, cell, resources, index):\\n'),\n",
     "    (False, ' from somewhere import something'),\n",
     "    (True, 'from somewhere import something'),\n",
-    "    (True, 'from '),\n",
+    "    (False, 'from '),\n",
+    "    (False, 'select * \\nfrom database'),\n",
     "    (False, ' import re'),\n",
     "    (True, 'import re'),\n",
     "    (True, 'import '),\n",
@@ -2403,5 +2404,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
`_re_import` now has stricter matching conditions for imports, so that it will not match `from xxxx` without the following `import`. This prevents code blocks that include things like
 
```py
query="""
select *
from database
"""
```
 
from running when generating docs due to the misclassification of it being imports. 

This can be a conner case, but the stricter condition would not miss any legitimate imports so it shouldn't hurt anything. 