### PR TITLE
Adding google colab cell tags to cell_metadata_keep

### DIFF
--- a/nbdev/clean.py
+++ b/nbdev/clean.py
@@ -33,7 +33,7 @@ def clean_cell_output(cell):
             clean_output_data_vnd(o)
 
 # Cell
-cell_metadata_keep = ["hide_input", "tags"]
+cell_metadata_keep = ["hide_input", "tags", "colab_type", "cellView"]
 nb_metadata_keep   = ["kernelspec", "jekyll", "jupytext", "doc"]
 
 # Cell

--- a/nbs/07_clean.ipynb
+++ b/nbs/07_clean.ipynb
@@ -119,7 +119,7 @@
    "outputs": [],
    "source": [
     "%nbdev_export\n",
-    "cell_metadata_keep = [\"hide_input\", \"tags\"]\n",
+    "cell_metadata_keep = [\"hide_input\", \"tags\", \"colab_type\", \"cellView\"]\n",
     "nb_metadata_keep   = [\"kernelspec\", \"jekyll\", \"jupytext\", \"doc\"]"
    ]
   },
@@ -346,5 +346,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
"colab_type" and "cellView" in cell metadata allow google colab to define cell type and view, e.g.,  "cellView": "form",
and "colab_type": "code" allow to completely hide a code cell and only show markdown in google colab
