### PR TITLE
adding show_source option to show_doc

### DIFF
--- a/nbdev/showdoc.py
+++ b/nbdev/showdoc.py
@@ -217,7 +217,7 @@ def format_param(p):
 def _format_enum_doc(enum, full_name):
     "Formatted `enum` definition to show in documentation"
     vals = ', '.join(enum.__members__.keys())
-    return f'<code>{full_name}</code>',f'<code>Enum</code> = [{vals}]'
+    return f'<code>{full_name}</code>',f'<code>Enum</code> = [{vals}]',f''
 
 # Cell
 def _escape_chars(s):
@@ -250,9 +250,9 @@ def show_doc(elt, doc_string=True, name=None, title_level=None, disp=True, defau
     elt = getattr(elt, '__func__', elt)
     qname = name or qual_name(elt)
     if inspect.isclass(elt):
-        if is_enum(elt): name,args,source = *_format_enum_doc(elt, qname), ''
-        else:            name,args,source =  _format_cls_doc (elt, qname)
-    elif callable(elt):  name,args,source =  _format_func_doc(elt, qname)
+        if is_enum(elt): name,args,source = _format_enum_doc(elt, qname)
+        else:            name,args,source = _format_cls_doc (elt, qname)
+    elif callable(elt):  name,args,source = _format_func_doc(elt, qname)
     else:                name,args,source = f"<code>{qname}</code>", '', ''
     link = get_source_link(elt)
     source_link = f'<a href="{link}" class="source_link" style="float:right">[source]</a>'

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -741,7 +741,7 @@
     "def _format_enum_doc(enum, full_name):\n",
     "    \"Formatted `enum` definition to show in documentation\"\n",
     "    vals = ', '.join(enum.__members__.keys())\n",
-    "    return f'<code>{full_name}</code>',f'<code>Enum</code> = [{vals}]'"
+    "    return f'<code>{full_name}</code>',f'<code>Enum</code> = [{vals}]',f''"
    ]
   },
   {
@@ -752,7 +752,7 @@
    "source": [
     "%nbdev_hide\n",
     "tst =  _format_enum_doc(e, 'e')\n",
-    "test_eq(tst, ('<code>e</code>', '<code>Enum</code> = [a, b]'))"
+    "test_eq(tst, ('<code>e</code>', '<code>Enum</code> = [a, b]', ''))"
    ]
   },
   {
@@ -830,9 +830,9 @@
     "    elt = getattr(elt, '__func__', elt)\n",
     "    qname = name or qual_name(elt)\n",
     "    if inspect.isclass(elt):\n",
-    "        if is_enum(elt): name,args,source = *_format_enum_doc(elt, qname), ''\n",
-    "        else:            name,args,source =  _format_cls_doc (elt, qname)\n",
-    "    elif callable(elt):  name,args,source =  _format_func_doc(elt, qname)\n",
+    "        if is_enum(elt): name,args,source = _format_enum_doc(elt, qname)\n",
+    "        else:            name,args,source = _format_cls_doc (elt, qname)\n",
+    "    elif callable(elt):  name,args,source = _format_func_doc(elt, qname)\n",
     "    else:                name,args,source = f\"<code>{qname}</code>\", '', ''\n",
     "    link = get_source_link(elt)\n",
     "    source_link = f'<a href=\"{link}\" class=\"source_link\" style=\"float:right\">[source]</a>'\n",

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -296,8 +296,8 @@
     "%nbdev_export\n",
     "def add_doc_links(text, elt=None):\n",
     "    \"Search for doc links for any item between backticks in `text` and isnter them\"\n",
-    "    def _replace_link(m): \n",
-    "        try: \n",
+    "    def _replace_link(m):\n",
+    "        try:\n",
     "            if m.group(2) in inspect.signature(elt).parameters: return f'`{m.group(2)}`'\n",
     "        except: pass\n",
     "        return doc_link(m.group(1) or m.group(2))\n",
@@ -774,8 +774,9 @@
     "    except: fmt_params = []\n",
     "    name = f'<code>{full_name or func.__name__}</code>'\n",
     "    arg_str = f\"({', '.join(fmt_params)})\"\n",
+    "    source = get_ipython().inspector._info(func, detail_level=1)[\"source\"]\n",
     "    f_name = f\"<code>class</code> {name}\" if inspect.isclass(func) else name\n",
-    "    return f'{f_name}',f'{name}{arg_str}'"
+    "    return f'{f_name}',f'{name}{arg_str}',f\"```python\\n{source}\\n```\""
    ]
   },
   {
@@ -785,8 +786,9 @@
    "outputs": [],
    "source": [
     "%nbdev_hide\n",
-    "test_eq(_format_func_doc(notebook2script), ('<code>notebook2script</code>', \n",
-    "   '<code>notebook2script</code>(**`fname`**=*`None`*, **`silent`**=*`False`*, **`to_dict`**=*`False`*)'))"
+    "test_eq(_format_func_doc(notebook2script), ('<code>notebook2script</code>',\n",
+    " '<code>notebook2script</code>(**`fname`**=*`None`*, **`silent`**=*`False`*, **`to_dict`**=*`False`*)',\n",
+    " '```python\\ndef notebook2script(fname=None, silent=False, to_dict=False):\\n    \"Convert notebooks matching `fname` to modules\"\\n    # initial checks\\n    if os.environ.get(\\'IN_TEST\\',0): return  # don\\'t export if running tests\\n    if fname is None:\\n        reset_nbdev_module()\\n        update_version()\\n        update_baseurl()\\n        files = [f for f in Config().nbs_path.glob(\\'*.ipynb\\') if not f.name.startswith(\\'_\\')]\\n    else: files = glob.glob(fname)\\n    d = collections.defaultdict(list) if to_dict else None\\n    modules = create_mod_files(files, to_dict)\\n    for f in sorted(files): d = _notebook2script(f, modules, silent=silent, to_dict=d)\\n    if to_dict: return d\\n    else: add_init(Config().lib_path)\\n```'))"
    ]
   },
   {
@@ -799,9 +801,9 @@
     "def _format_cls_doc(cls, full_name):\n",
     "    \"Formatted `cls` definition to show in documentation\"\n",
     "    parent_class = inspect.getclasstree([cls])[-1][0][1][0]\n",
-    "    name,args = _format_func_doc(cls, full_name)\n",
+    "    name,args,source = _format_func_doc(cls, full_name)\n",
     "    if parent_class != object: args += f' :: {doc_link(get_name(parent_class))}'\n",
-    "    return name,args"
+    "    return name,args,source"
    ]
   },
   {
@@ -811,8 +813,9 @@
    "outputs": [],
    "source": [
     "%nbdev_hide\n",
-    "test_eq(_format_cls_doc(DocsTestClass, 'DocsTestClass'), ('<code>class</code> <code>DocsTestClass</code>', \n",
-    "                                                          '<code>DocsTestClass</code>()'))"
+    "test_eq(_format_cls_doc(DocsTestClass, 'DocsTestClass'), ('<code>class</code> <code>DocsTestClass</code>',\n",
+    " '<code>DocsTestClass</code>()',\n",
+    " '```python\\nclass DocsTestClass:\\n    \"for tests only\"\\n    def test(): pass\\n```'))"
    ]
   },
   {
@@ -822,15 +825,15 @@
    "outputs": [],
    "source": [
     "%nbdev_export\n",
-    "def show_doc(elt, doc_string=True, name=None, title_level=None, disp=True, default_cls_level=2):\n",
+    "def show_doc(elt, doc_string=True, name=None, title_level=None, disp=True, default_cls_level=2, show_source=False):\n",
     "    \"Show documentation for element `elt`. Supported types: class, function, and enum.\"\n",
     "    elt = getattr(elt, '__func__', elt)\n",
     "    qname = name or qual_name(elt)\n",
     "    if inspect.isclass(elt):\n",
-    "        if is_enum(elt): name,args = _format_enum_doc(elt, qname)\n",
-    "        else:            name,args = _format_cls_doc (elt, qname)\n",
-    "    elif callable(elt):  name,args = _format_func_doc(elt, qname)\n",
-    "    else:                name,args = f\"<code>{qname}</code>\", ''\n",
+    "        if is_enum(elt): name,args,source = *_format_enum_doc(elt, qname), ''\n",
+    "        else:            name,args,source =  _format_cls_doc (elt, qname)\n",
+    "    elif callable(elt):  name,args,source =  _format_func_doc(elt, qname)\n",
+    "    else:                name,args,source = f\"<code>{qname}</code>\", '', ''\n",
     "    link = get_source_link(elt)\n",
     "    source_link = f'<a href=\"{link}\" class=\"source_link\" style=\"float:right\">[source]</a>'\n",
     "    title_level = title_level or (default_cls_level if inspect.isclass(elt) else 4)\n",
@@ -844,6 +847,7 @@
     "        # doc links don't work inside markdown pre/code blocks\n",
     "        s = f'```\\n{s}\\n```' if monospace else add_doc_links(s, elt)\n",
     "        doc += s\n",
+    "    doc += f\"\\n\\n{source}\\n\" if show_source else ''\n",
     "    if disp: display(Markdown(doc))\n",
     "    else: return doc"
    ]
@@ -852,7 +856,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`doc_string` determines if we show the docstring of the function or not. `name` can be used to provide an alternative to the name automatically found. `title_level` determines the level of the anchor (default 3 for classes and 4 for functions). If `disp` is `False`, the function returns the markdown code instead of displaying it. If `doc_string` is `True` and `monospace_docstrings` is set to `True` in `settings.ini`, the docstring of the function is formatted in a code block to preserve whitespace."
+    "`doc_string` determines if we show the docstring of the function or not. `name` can be used to provide an alternative to the name automatically found. `title_level` determines the level of the anchor (default 3 for classes and 4 for functions). If `disp` is `False`, the function returns the markdown code instead of displaying it. If `doc_string` is `True` and `monospace_docstrings` is set to `True` in `settings.ini`, the docstring of the function is formatted in a code block to preserve whitespace.  `show_source` is an option parameter that will also append the source code of the function to the end of the documentation."
    ]
   },
   {
@@ -890,6 +894,60 @@
    ],
    "source": [
     "show_doc(notebook2script)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Adding the `show_source` argument will also display the source code for the function. \n",
+    "```python\n",
+    "show_doc(notebook2script, show_source=True)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"notebook2script\" class=\"doc_header\"><code>notebook2script</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L454\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>notebook2script</code>(**`fname`**=*`None`*, **`silent`**=*`False`*, **`to_dict`**=*`False`*)\n",
+       "\n",
+       "Convert notebooks matching `fname` to modules\n",
+       "\n",
+       "```python\n",
+       "def notebook2script(fname=None, silent=False, to_dict=False):\n",
+       "    \"Convert notebooks matching `fname` to modules\"\n",
+       "    # initial checks\n",
+       "    if os.environ.get('IN_TEST',0): return  # don't export if running tests\n",
+       "    if fname is None:\n",
+       "        reset_nbdev_module()\n",
+       "        update_version()\n",
+       "        update_baseurl()\n",
+       "        files = [f for f in Config().nbs_path.glob('*.ipynb') if not f.name.startswith('_')]\n",
+       "    else: files = glob.glob(fname)\n",
+       "    d = collections.defaultdict(list) if to_dict else None\n",
+       "    modules = create_mod_files(files, to_dict)\n",
+       "    for f in sorted(files): d = _notebook2script(f, modules, silent=silent, to_dict=d)\n",
+       "    if to_dict: return d\n",
+       "    else: add_init(Config().lib_path)\n",
+       "```\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "show_doc(notebook2script, show_source=True)"
    ]
   },
   {


### PR DESCRIPTION
This is an option that seemed like it would have been useful when writing a blog post and nbdev's show_doc seemed like a good spot to put it.  This gives the user the option to show_source when they do a show_doc.  By default this will be disabled so it shouldn't break anything else unless somebody was using `_format_func_doc` or `_format_cls_doc` directly.  