### PR TITLE
Fix: correct notebook2html path operation for Windows.

### DIFF
--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -566,7 +566,7 @@ def notebook2html(fname=None, force_all=False, n_workers=None, cls=HTMLExporter,
     "Convert all notebooks matching `fname` to html files"
     if fname is None:
         files = [f for f in Config().nbs_path.glob('**/*.ipynb')
-                 if not f.name.startswith('_') and not '/.' in str(f)]
+                 if not f.name.startswith('_') and not '/.' in f.as_posix()]
     else:
         p = Path(fname)
         files = list(p.parent.glob(p.name))

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -1876,7 +1876,7 @@
     "    \"Convert all notebooks matching `fname` to html files\"\n",
     "    if fname is None:\n",
     "        files = [f for f in Config().nbs_path.glob('**/*.ipynb')\n",
-    "                 if not f.name.startswith('_') and not '/.' in str(f)]\n",
+    "                 if not f.name.startswith('_') and not '/.' in f.as_posix()]\n",
     "    else:\n",
     "        p = Path(fname)\n",
     "        files = list(p.parent.glob(p.name))\n",


### PR DESCRIPTION
With the default project structure, the glob() in notebook2html() can easilly find a copy of a .ipynb file in .ipynb_checkpoints. In this case, running nbdev_build_docs will fail, assuming the .ipynb imports the project (the relative path is not correct from this dir.) The current code to skip hidden path components searches for '/.', whereas str(f) will return the Windows backslash path, so the search will fail. f.as_posix() returns a '/' delimited path on all platforms.

I verified failure of nbdev_build_docs before the fix, and success after installing the fix.