### PR TITLE
Magic flags ipython extension

### DIFF
--- a/nbdev/flags.py
+++ b/nbdev/flags.py
@@ -116,4 +116,7 @@ if IN_IPYTHON:
     except: pass # do not fail if we can't find config
 
 def load_ipython_extension(ipython):
-    "This function makes `nbdev.flags` an ipython extension. No logic needed - we just need imports to run"
+    "You can `%load_ext nbdev.flags` to make magic flags, show_doc and notebook2script available in a notebook"
+    from .showdoc import show_doc
+    from .export import notebook2script
+    ipython.push(dict(show_doc=show_doc,notebook2script=notebook2script))

--- a/nbdev/flags.py
+++ b/nbdev/flags.py
@@ -115,3 +115,5 @@ if IN_IPYTHON:
         for flag in Config().get('tst_flags', '').split('|'): _new_test_flag_fn(flag)
     except: pass # do not fail if we can't find config
 
+def load_ipython_extension(ipython):
+    "This function makes `nbdev.flags` an ipython extension. No logic needed - we just need imports to run"

--- a/nbs/00_export.ipynb
+++ b/nbs/00_export.ipynb
@@ -17,7 +17,6 @@
     }
    ],
    "source": [
-    "from nbdev import *\n",
     "%nbdev_default_export export\n",
     "%nbdev_default_class_level 3"
    ]
@@ -81,7 +80,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"Config\" class=\"doc_header\"><code>Config</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/imports.py#L37\" class=\"source_link\" style=\"float:right\">[source]</a></h3>\n",
+       "<h3 id=\"Config\" class=\"doc_header\"><code>Config</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/imports.py#L38\" class=\"source_link\" style=\"float:right\">[source]</a></h3>\n",
        "\n",
        "> <code>Config</code>(**`cfg_name`**=*`'settings.ini'`*)\n",
        "\n",
@@ -163,7 +162,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"last_index\" class=\"doc_header\"><code>last_index</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L199\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"last_index\" class=\"doc_header\"><code>last_index</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L216\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>last_index</code>(**`x`**, **`o`**)\n",
        "\n",
@@ -200,7 +199,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"compose\" class=\"doc_header\"><code>compose</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L365\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"compose\" class=\"doc_header\"><code>compose</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L384\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>compose</code>(**\\*`funcs`**, **`order`**=*`None`*)\n",
        "\n",
@@ -239,9 +238,9 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"parallel\" class=\"doc_header\"><code>parallel</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L715\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"parallel\" class=\"doc_header\"><code>parallel</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L728\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
-       "> <code>parallel</code>(**`f`**, **`items`**, **\\*`args`**, **`n_workers`**=*`64`*, **`total`**=*`None`*, **`progress`**=*`None`*, **`pause`**=*`0`*, **\\*\\*`kwargs`**)\n",
+       "> <code>parallel</code>(**`f`**, **`items`**, **\\*`args`**, **`n_workers`**=*`12`*, **`total`**=*`None`*, **`progress`**=*`None`*, **`pause`**=*`0`*, **\\*\\*`kwargs`**)\n",
        "\n",
        "Applies `func` in parallel to `items`, using `n_workers`"
       ],
@@ -434,9 +433,9 @@
        "  'version': '3.7.7'},\n",
        " 'toc': {'base_numbering': 1,\n",
        "  'nav_menu': {},\n",
-       "  'number_sections': False,\n",
+       "  'number_sections': True,\n",
        "  'sideBar': True,\n",
-       "  'skip_h1_title': True,\n",
+       "  'skip_h1_title': False,\n",
        "  'title_cell': 'Table of Contents',\n",
        "  'title_sidebar': 'Contents',\n",
        "  'toc_cell': False,\n",
@@ -490,12 +489,12 @@
      "data": {
       "text/plain": [
        "{'cell_type': 'code',\n",
-       " 'execution_count': 1,\n",
+       " 'execution_count': None,\n",
        " 'metadata': {'hide_input': True},\n",
        " 'outputs': [{'name': 'stdout',\n",
        "   'output_type': 'stream',\n",
        "   'text': 'Cells will be exported to nbdev.export,\\nunless a different module is specified after an export flag: `%nbdev_export special.module`\\n'}],\n",
-       " 'source': 'from nbdev import *\\n%nbdev_default_export export\\n%nbdev_default_class_level 3'}"
+       " 'source': '%nbdev_default_export export\\n%nbdev_default_class_level 3'}"
       ]
      },
      "execution_count": null,
@@ -2228,10 +2227,10 @@
       "Converted 05a_conda.ipynb.\n",
       "Converted 06_cli.ipynb.\n",
       "Converted 07_clean.ipynb.\n",
-      "Converted 08_flag_tests.ipynb.\n",
-      "Converted 09_nbdev_callback_test.ipynb.\n",
       "Converted 99_search.ipynb.\n",
       "Converted index.ipynb.\n",
+      "Converted magic_flags.ipynb.\n",
+      "Converted nbdev_callbacks.ipynb.\n",
       "Converted tutorial.ipynb.\n"
      ]
     }

--- a/nbs/ipython_config.py
+++ b/nbs/ipython_config.py
@@ -1,0 +1,1 @@
+c.InteractiveShellApp.extensions = ['nbdev.flags']

--- a/nbs/magic_flags.ipynb
+++ b/nbs/magic_flags.ipynb
@@ -31,16 +31,44 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Using magic flags"
+    "## Making magic flags available in your notebooks"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "from nbdev import *"
+    "There are a few different ways to make magic flags available in your notebooks:\n",
+    "\n",
+    "1) Import anything from `nbdev`\n",
+    "\n",
+    "```python\n",
+    "from nbdev import *\n",
+    "```\n",
+    "\n",
+    "2) Load `nbdev.flags` as an ipython extension\n",
+    "\n",
+    "```python\n",
+    "%load_ext nbdev.flags\n",
+    "```\n",
+    "\n",
+    "3) Automatically load `nbdev.flags` as an ipython extension via [ipython_config.py](https://ipython.readthedocs.io/en/stable/config/intro.html)\n",
+    "\n",
+    "If you don't already have configuration files setup, you can create `ipython_config.py` in your nbs path with just the following line:\n",
+    "```\n",
+    "c.InteractiveShellApp.extensions = ['nbdev.flags']\n",
+    "```\n",
+    "\n",
+    "This nice thing about this approach is that all notebooks in your nbdev project will have access to magic flags as soon as they are loaded.\n",
+    "\n",
+    "*Note*: All of these options will also import `show_doc` and `notebook2script`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using magic flags"
    ]
   },
   {
@@ -392,11 +420,10 @@
       "Converted 05a_conda.ipynb.\n",
       "Converted 06_cli.ipynb.\n",
       "Converted 07_clean.ipynb.\n",
-      "Converted 08_flag_tests.ipynb.\n",
-      "Converted 09_nbdev_callback_test.ipynb.\n",
-      "Converted 10_release.ipynb.\n",
       "Converted 99_search.ipynb.\n",
       "Converted index.ipynb.\n",
+      "Converted magic_flags.ipynb.\n",
+      "Converted nbdev_callbacks.ipynb.\n",
       "Converted tutorial.ipynb.\n"
      ]
     }

--- a/nbs/magic_flags.ipynb
+++ b/nbs/magic_flags.ipynb
@@ -59,7 +59,7 @@
     "c.InteractiveShellApp.extensions = ['nbdev.flags']\n",
     "```\n",
     "\n",
-    "This nice thing about this approach is that all notebooks in your nbdev project will have access to magic flags as soon as they are loaded.\n",
+    "The nice thing about this approach is that all notebooks in your nbdev project will have access to magic flags as soon as they are loaded.\n",
     "\n",
     "*Note*: All of these options will also import `show_doc` and `notebook2script`."
    ]


### PR DESCRIPTION
Hi @jph00 - do you think it would be nicer to load magic flags as an ipython extension? so you don't have to `import nbdev` to get magic flags.

I've removed `from nbdev import *` from `00_export.ipynb` to make use of the 3rd option described in `magic_flags.ipynb` - let me know if you like this approach and I'll update the other notebooks.
If you'd prefer not to use `ipython_config.py`, we could change the imports to `%load_ext nbdev.flags`.

While this works in colab ...
```
!pip install git+https://github.com/pete88b/nbdev.git@magic-flags-ipython-extension
%load_ext nbdev.flags
```
I don't think https://github.com/pete88b/nbdev_colab_helper is ready to be referenced in the nbdev docs yet