### PR TITLE
Updated nbdev to use 6.0 with pre-existing 5.x templates

### DIFF
--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -510,14 +510,19 @@ def write_tmpls():
 
 # Cell
 def nbdev_exporter(cls=HTMLExporter, template_file=None):
-    cfg = traitlets.config.Config()
-    exporter = cls(cfg)
-    exporter.exclude_input_prompt=True
-    exporter.exclude_output_prompt=True
-    exporter.anchor_link_text = ' '
-    exporter.template_file = 'jekyll.tpl' if template_file is None else template_file
-    exporter.template_path.append(str(Path(__file__).parent/'templates'))
-    return exporter
+    # For backwards comaptability of 5.x style templates, we pass a full template_file path
+    # instead of manipulating template_paths
+    if not template_file:
+        template_file = 'jekyll.tpl'
+    if template_file and not os.path.isabs(template_file):
+        template_file = str(Path(__file__).parent/'templates'/template_file)
+    cfg = traitlets.config.Config(
+        exclude_input_prompt=True,
+        exclude_output_prompt=True,
+        anchor_link_text=' ',
+        template_file=template_file,
+    )
+    return cls(cfg)
 
 # Cell
 process_cells = [remove_fake_headers, remove_hidden, remove_empty]

--- a/nbdev/templates/hide-md.tpl
+++ b/nbdev/templates/hide-md.tpl
@@ -1,4 +1,4 @@
-{%- extends 'markdown.tpl' -%}
+{%- extends 'markdown/index.md.j2' -%}
 
 {% block input_group -%}
 {%- if cell.metadata.collapse_show -%}

--- a/nbdev/templates/hide.tpl
+++ b/nbdev/templates/hide.tpl
@@ -1,4 +1,4 @@
-{%- extends 'basic.tpl' -%}
+{%- extends 'classic/index.html.j2' -%}
 
 {% block codecell %}
     {{ "{% raw %}" }}

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -1774,14 +1774,19 @@
    "source": [
     "#export\n",
     "def nbdev_exporter(cls=HTMLExporter, template_file=None):\n",
-    "    cfg = traitlets.config.Config()\n",
-    "    exporter = cls(cfg)\n",
-    "    exporter.exclude_input_prompt=True\n",
-    "    exporter.exclude_output_prompt=True\n",
-    "    exporter.anchor_link_text = ' '\n",
-    "    exporter.template_file = 'jekyll.tpl' if template_file is None else template_file\n",
-    "    exporter.template_path.append(str(Path(__file__).parent/'templates'))\n",
-    "    return exporter"
+    "    # For backwards comaptability of 5.x style templates, we pass a full template_file path\n",
+    "    # instead of manipulating template_paths\n",
+    "    if not template_file:\n",
+    "        template_file = 'jekyll.tpl'\n",
+    "    if template_file and not os.path.isabs(template_file):\n",
+    "        template_file = str(Path(__file__).parent/'templates'/template_file)\n",
+    "    cfg = traitlets.config.Config(\n",
+    "        exclude_input_prompt=True,\n",
+    "        exclude_output_prompt=True,\n",
+    "        anchor_link_text=' ',\n",
+    "        template_file=template_file,\n",
+    "    )\n",
+    "    return cls(cfg)"
    ]
   },
   {

--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ status = 4
 min_python = 3.6
 audience = Developers
 language = English
-requirements = fastcore>=1.0.5 nbformat>=4.4.0 nbconvert<6 pyyaml fastscript>=1.0.0 jupyter_client ipykernel
+requirements = fastcore>=1.0.5 nbformat>=4.4.0 nbconvert>=6.0.2 pyyaml fastscript>=1.0.0 jupyter_client>=6.1.5 ipykernel
 conda_requirements = nb_conda
 console_scripts = nbdev_build_lib=nbdev.cli:nbdev_build_lib
 	nbdev_update_lib=nbdev.cli:nbdev_update_lib


### PR DESCRIPTION
I believe this fixes all the issues for nbconvert 6.0 usage.

I left the templates in 5.x style and used the template_file backwards compatibility supported path for referencing them to keep the PR minimal. NBconvert 6.0 introduced templates as a directories so that it can include config files and multiple jinja files that can be composed as a unit. https://nbconvert.readthedocs.io/en/latest/customizing.html has guides on how this works and how to extend it now if you wish to change to the new pattern.

`make test` complains about `06_cli.ipynb` where the id fields of the two values don't match. But this is happening for me on master with nbconvert 5.6.1 so I think it's unrelated.

`jupyter_client` was given a min version because it's caused issues for other libraries where the min version pin in nbclient isn't respected by pip in all scenarios due to it being a nested transitive dependency.