### PR TITLE
Fix inconsistent usage of %nbdev_export in the tutorial notebook

### DIFF
--- a/nbs/tutorial.ipynb
+++ b/nbs/tutorial.ipynb
@@ -259,7 +259,7 @@
     "Let's add a function to this notebook, e.g.:\n",
     "\n",
     "```python\n",
-    "#export\n",
+    "%nbdev_export\n",
     "def say_hello(to):\n",
     "    \"Say hello to somebody\"\n",
     "    return f'Hello {to}!'\n",
@@ -274,7 +274,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#export\n",
+    "%nbdev_export\n",
     "def say_hello(to):\n",
     "    \"Say hello to somebody\"\n",
     "    return f'Hello {to}!'"
@@ -500,7 +500,7 @@
     "Create a class in `00_core.ipynb` as follows:\n",
     "\n",
     "```python\n",
-    "#export\n",
+    "%nbdev_export\n",
     "class HelloSayer:\n",
     "    \"Say hello to `to` using `say_hello`\"\n",
     "    def __init__(self, to): self.to = to\n",
@@ -519,7 +519,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#export\n",
+    "%nbdev_export\n",
     "class HelloSayer:\n",
     "    \"Say hello to `to` using `say_hello`\"\n",
     "    def __init__(self, to): self.to = to\n",


### PR DESCRIPTION
Hi, just a very minor change in `tutorial.ipynb`. I replaced `#export` with `%nbdev_export`, since the latter is referenced in the accompanying instructions.