### PR TITLE
Add example for specification of requirements to tutorial.ipynb

### DIFF
--- a/nbs/tutorial.ipynb
+++ b/nbs/tutorial.ipynb
@@ -704,7 +704,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If your module requires other modules as dependencies, you can add those prerequisites to your `settings.ini` in the `requirements` section. This should be in the same format as [install_requires in setuptools](https://packaging.python.org/discussions/install-requires-vs-requirements/#install-requires), with each requirement separated by a space."
+    "If your module requires other modules as dependencies, you can add those prerequisites to your `settings.ini` in the `requirements` section. The requirements should be separated by a space and if the module requires at least or at most a specific version of the requirement this may be specified here, too.\n",
+    "\n",
+    "For example if your module requires the `fastcore` module of at least version 1.0.5, the `torchvision` module of at most version 0.7 and any version of `matplotlib`, then the prerequisites would look like this:\n",
+    "```python\n",
+    "requirements = fastcore>=1.0.5 torchvision<0.7 matplotlib\n",
+    "```"
    ]
   },
   {


### PR DESCRIPTION
Hi,

I am proposing to change the instructions in `tutorial.ipynb` to specify the `requirements` in `settings.ini`.
Specifying the `requirements` in `settings.ini` as described in [install_requires in setuptools](https://packaging.python.org/discussions/install-requires-vs-requirements/#install-requires) leads to a parse error in the build within GitHub Actions.

The link given in `tutorial.ipynb` implies the following format:
```python
requirements = ['fastcore>=1.0.5', 'torchvision<0.7', 'matplotlib']
```
which would lead to a parse error. 

A format that does _not_ cause a parse error is
```python
requirements = fastcore>=1.0.5 torchvision<0.7 matplotlib
```