### PR TITLE
Filter notebooks stored in ".ipynb_checkpoints" dirs from html genera…

### DIFF
--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -704,7 +704,7 @@ def _get_title(fname):
 def _create_default_sidebar():
     "Create the default sidebar for the docs website"
     dic = {"Overview": "/"}
-    files = [f for f in Config().nbs_path.glob('**/*.ipynb') if not f.name.startswith('_')]
+    files = [f for f in Config().nbs_path.glob('**/*.ipynb') if not f.name.startswith('_') and '.ipynb_checkpoints' not in f.parts]
     fnames = [_nb2htmlfname(f) for f in sorted(files)]
     titles = [_get_title(f) for f in fnames if 'index' not in f.stem!='index']
     if len(titles) > len(set(titles)): print(f"Warning: Some of your Notebooks use the same title ({titles}).")

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -2358,47 +2358,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.7"
-  },
-  "varInspector": {
-   "cols": {
-    "lenName": 16,
-    "lenType": 16,
-    "lenVar": 40
-   },
-   "kernels_config": {
-    "python": {
-     "delete_cmd_postfix": "",
-     "delete_cmd_prefix": "del ",
-     "library": "var_list.py",
-     "varRefreshCmd": "print(var_dic_list())"
-    },
-    "r": {
-     "delete_cmd_postfix": ") ",
-     "delete_cmd_prefix": "rm(",
-     "library": "var_list.r",
-     "varRefreshCmd": "cat(var_dic_list()) "
-    }
-   },
-   "types_to_exclude": [
-    "module",
-    "function",
-    "builtin_function_or_method",
-    "instance",
-    "_Feature"
-   ],
-   "window_display": false
   }
  },
  "nbformat": 4,

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -2252,7 +2252,7 @@
     "def _create_default_sidebar():\n",
     "    \"Create the default sidebar for the docs website\"\n",
     "    dic = {\"Overview\": \"/\"}\n",
-    "    files = [f for f in Config().nbs_path.glob('**/*.ipynb') if not f.name.startswith('_')]\n",
+    "    files = [f for f in Config().nbs_path.glob('**/*.ipynb') if not f.name.startswith('_') and '.ipynb_checkpoints' not in f.parts]\n",
     "    fnames = [_nb2htmlfname(f) for f in sorted(files)]\n",
     "    titles = [_get_title(f) for f in fnames if 'index' not in f.stem!='index']\n",
     "    if len(titles) > len(set(titles)): print(f\"Warning: Some of your Notebooks use the same title ({titles}).\")\n",
@@ -2358,6 +2358,47 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi, @jph00 

I encountered this problem because jupyter notebook creates these hidden directories `.ipynb_checkpoints` inside the
same dirs as where the notebooks are located. 

Jupyter then saves versioned copies of the main notebooks inside these directories and these are then named `xxxx-checkpoint.ipynb` where `xxxx.ipynb` is original notebook. 

This then cascades a file open error since `_get_title` will look for the generated html file name (generated by `_nb2htmlfname`) does not exist.

This problem doesn't show up on Github CI since `.ipynb_checkpoints` are git ignored and are never exported to github,
but it does show up if you call nbdev_build_docs in a local environment where jupyter notebooks have been saved with
checkpoints.

My fix is to just filter out those notebooks inside `.ipynb_checkpoints` directories.

Best regards,
Butch