### PR TITLE
Generate link without html prefix

### DIFF
--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -708,7 +708,7 @@ def _create_default_sidebar():
     fnames = [_nb2htmlfname(f) for f in sorted(files)]
     titles = [_get_title(f) for f in fnames if 'index' not in f.stem!='index']
     if len(titles) > len(set(titles)): print(f"Warning: Some of your Notebooks use the same title ({titles}).")
-    dic.update({_get_title(f):f'{f.name}' for f in fnames if f.stem!='index'})
+    dic.update({_get_title(f):f'{f.stem}' for f in fnames if f.stem!='index'})
     return dic
 
 # Cell

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -2256,7 +2256,7 @@
     "    fnames = [_nb2htmlfname(f) for f in sorted(files)]\n",
     "    titles = [_get_title(f) for f in fnames if 'index' not in f.stem!='index']\n",
     "    if len(titles) > len(set(titles)): print(f\"Warning: Some of your Notebooks use the same title ({titles}).\")\n",
-    "    dic.update({_get_title(f):f'{f.name}' for f in fnames if f.stem!='index'})\n",
+    "    dic.update({_get_title(f):f'{f.stem}' for f in fnames if f.stem!='index'})\n",
     "    return dic"
    ]
   },


### PR DESCRIPTION
Hi @jph00,

I encountered an error where the doc site generated the wrong links in the sidebar to the subpages in the main site.

The new subpages are now created in the subfolders with the file 'index.html'.  (see `docs/_site` to 
see what I mean).

My fix removes the html suffix to the link  and creates the correct link to the folder for the document 
sub pages.

Best regards,
Butch