### PR TITLE
fix docs link bug

### DIFF
--- a/nbdev/showdoc.py
+++ b/nbdev/showdoc.py
@@ -284,7 +284,7 @@ def get_doc_link(func):
         nbdev_mod = importlib.import_module(mod.__package__.split('.')[0] + '._nbdev')
         try_pack = source_nb(func, mod=nbdev_mod)
         if try_pack:
-            page = '.'.join(try_pack.split('_')[1:]).replace('.ipynb', '')
+            page = '.'.join(try_pack.partition('_')[-1:]).replace('.ipynb', '')
             return f'{nbdev_mod.doc_url}{page}#{qual_name(func)}'
     except: return None
 

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -378,21 +378,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AssertionError",
-     "evalue": "==:\nLets talk about `add_doc_links`\nLets talk about [`add_doc_links`](/showdoc.html#add_doc_links)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-20-d6ca6c320cfa>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0madd_doc_links\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;32mpass\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m test_eq(add_doc_links('Lets talk about `add_doc_links`'), \n\u001b[0;32m----> 4\u001b[0;31m         'Lets talk about [`add_doc_links`](/showdoc.html#add_doc_links)')\n\u001b[0m\u001b[1;32m      5\u001b[0m \u001b[0mtest_eq\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0madd_doc_links\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Lets talk about `add_doc_links`'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mT\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'Lets talk about `add_doc_links`'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m test_eq(add_doc_links('Lets talk about `doc_link`'), \n",
-      "\u001b[0;32m~/git/fastcore/fastcore/test.py\u001b[0m in \u001b[0;36mtest_eq\u001b[0;34m(a, b)\u001b[0m\n\u001b[1;32m     32\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0mtest_eq\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mb\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     33\u001b[0m     \u001b[0;34m\"`test` that `a==b`\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 34\u001b[0;31m     \u001b[0mtest\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mb\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mequals\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'=='\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     35\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     36\u001b[0m \u001b[0;31m# Cell\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/git/fastcore/fastcore/test.py\u001b[0m in \u001b[0;36mtest\u001b[0;34m(a, b, cmp, cname)\u001b[0m\n\u001b[1;32m     22\u001b[0m     \u001b[0;34m\"`assert` that `cmp(a,b)`; display inputs and `cname or cmp.__name__` if it fails\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     23\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mcname\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mcname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcmp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 24\u001b[0;31m     \u001b[0;32massert\u001b[0m \u001b[0mcmp\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mb\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34mf\"{cname}:\\n{a}\\n{b}\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     25\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m \u001b[0;31m# Cell\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAssertionError\u001b[0m: ==:\nLets talk about `add_doc_links`\nLets talk about [`add_doc_links`](/showdoc.html#add_doc_links)"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "class T:\n",
     "    def __init__(self, add_doc_links): pass\n",
@@ -523,7 +509,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "[Open `02_showdoc` in Colab](https://colab.research.google.com/github/fastai/nbdev/blob/master/nbs/02_showdoc.ipynb)"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "colab_link('02_showdoc')"
    ]
@@ -613,7 +612,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "[check_re (GitHub)](https://nbviewer.jupyter.org/github/fastai/nbdev/tree/master/nbs/00_export.ipynb#Finding-patterns)"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "test_eq(nb_source_link(check_re, disp=False), f'00_export.ipynb#Finding-patterns')\n",
     "test_eq(nb_source_link('check_re', disp=False), f'00_export.ipynb#Finding-patterns')\n",
@@ -850,7 +862,24 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"notebook2script\" class=\"doc_header\"><code>notebook2script</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L401\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>notebook2script</code>(**`fname`**=*`None`*, **`silent`**=*`False`*, **`to_dict`**=*`False`*)\n",
+       "\n",
+       "Convert notebooks matching `fname` to modules"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "show_doc(notebook2script)"
    ]
@@ -881,7 +910,24 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h2 id=\"DocsTestClass\" class=\"doc_header\"><code>class</code> <code>DocsTestClass</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L418\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\n",
+       "\n",
+       "> <code>DocsTestClass</code>()\n",
+       "\n",
+       "for tests only"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#hide\n",
     "show_doc(DocsTestClass)"
@@ -891,7 +937,23 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"DocsTestClass.test\" class=\"doc_header\"><code>DocsTestClass.test</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L420\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>DocsTestClass.test</code>()\n",
+       "\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#hide\n",
     "show_doc(DocsTestClass.test)"
@@ -901,7 +963,24 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"check_re\" class=\"doc_header\"><code>check_re</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L21\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>check_re</code>(**`cell`**, **`pat`**, **`code_only`**=*`True`*)\n",
+       "\n",
+       "Check if `cell` contains a line with regex `pat`"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#hide\n",
     "show_doc(check_re)"
@@ -911,7 +990,24 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h2 id=\"e\" class=\"doc_header\"><code>e</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\n",
+       "\n",
+       "> <code>Enum</code> = [a, b]\n",
+       "\n",
+       "An enumeration."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#hide\n",
     "show_doc(e)"
@@ -921,7 +1017,52 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"test_func_with_args_and_links\" class=\"doc_header\"><code>test_func_with_args_and_links</code><a href=\"__main__.py#L2\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>test_func_with_args_and_links</code>(**`foo`**, **`bar`**)\n",
+       "\n",
+       "Doc link: [`show_doc`](/showdoc.html#show_doc).\n",
+       "Args:\n",
+       "    foo: foo\n",
+       "    bar: bar\n",
+       "Returns:\n",
+       "    None"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"test_func_with_args_and_links\" class=\"doc_header\"><code>test_func_with_args_and_links</code><a href=\"__main__.py#L2\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>test_func_with_args_and_links</code>(**`foo`**, **`bar`**)\n",
+       "\n",
+       "```\n",
+       "Doc link: `show_doc`.\n",
+       "Args:\n",
+       "    foo: foo\n",
+       "    bar: bar\n",
+       "Returns:\n",
+       "    None\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#hide\n",
     "def test_func_with_args_and_links(foo, bar):\n",
@@ -976,7 +1117,7 @@
     "        nbdev_mod = importlib.import_module(mod.__package__.split('.')[0] + '._nbdev')\n",
     "        try_pack = source_nb(func, mod=nbdev_mod)\n",
     "        if try_pack:\n",
-    "            page = '.'.join(try_pack.split('_')[1:]).replace('.ipynb', '')\n",
+    "            page = '.'.join(try_pack.partition('_')[-1:]).replace('.ipynb', '')\n",
     "            return f'{nbdev_mod.doc_url}{page}#{qual_name(func)}'\n",
     "    except: return None"
    ]
@@ -1043,14 +1184,12 @@
       "Converted 03_export2html.ipynb.\n",
       "Converted 04_test.ipynb.\n",
       "Converted 05_merge.ipynb.\n",
-      "Converted 05a_conda.ipynb.\n",
       "Converted 06_cli.ipynb.\n",
       "Converted 07_clean.ipynb.\n",
-      "Converted 10_release.ipynb.\n",
       "Converted 99_search.ipynb.\n",
+      "Converted example.ipynb.\n",
       "Converted index.ipynb.\n",
-      "Converted magic_flags.ipynb.\n",
-      "Converted nbdev_callbacks.ipynb.\n",
+      "Converted try_save.ipynb.\n",
       "Converted tutorial.ipynb.\n"
      ]
     }


### PR DESCRIPTION

**I checked all the filenames in fastai/fastai and this fix would fix the following bugs.  All other URLs stay exactly the same.**

NEW URL | OLD URL
-- | --
https://docs.fast.ai/torch_core | https://docs.fast.ai/torch.core
https://docs.fast.ai/tutorial.medical_imaging | https://docs.fast.ai/tutorial.medical.imaging
https://docs.fast.ai/test_utils | https://docs.fast.ai/test.utils
https://docs.fast.ai/pytorch_doc | https://docs.fast.ai/pytorch.doc

_P.S. I'm not sure the best way to add an additional test for this, as I would have to either import fastai which I don't want to add that dependency to nbdev, and to create some kind of new fake code that I export which I don't want to do either._
