### PR TITLE
Added support for imports with custom spacing

### DIFF
--- a/nbdev/sync.py
+++ b/nbdev/sync.py
@@ -79,17 +79,17 @@ def relimport2name(name, mod_name):
 
 # Cell
 #Catches any from .bla import something and catches .bla in group 1, the imported thing(s) in group 2.
-_re_loc_import = re.compile(r'(^\s*)from (\.\S*) import (.*)$')
-_re_loc_import1 = re.compile(r'(^\s*)import (\.\S*)(.*)$')
+_re_loc_import = re.compile(r'(\s*)from(\s+)(\.\S*)(\s+)import(\s+)(.*)$')
+_re_loc_import1 = re.compile(r'(\s*)import(\s+)(\.\S*)(.*)$')
 
 # Cell
 def _deal_loc_import(code, fname):
     def _replace(m):
-        sp,mod,obj = m.groups()
-        return f"{sp}from {relimport2name(mod, fname)} import {obj}"
+        s1,s2,mod,s3,s4,obj = m.groups()
+        return f"{s1}from{s2}{relimport2name(mod, fname)}{s3}import{s4}{obj}"
     def _replace1(m):
-        sp,mod,end = m.groups()
-        return f"{sp}import {relimport2name(mod, fname)}{end}"
+        s1,s2,mod,end = m.groups()
+        return f"{s1}import{s2}{relimport2name(mod, fname)}{end}"
     return '\n'.join([_re_loc_import1.sub(_replace1, _re_loc_import.sub(_replace,line)) for line in code.split('\n')])
 
 # Cell

--- a/nbs/01_sync.ipynb
+++ b/nbs/01_sync.ipynb
@@ -298,8 +298,8 @@
    "source": [
     "#export\n",
     "#Catches any from .bla import something and catches .bla in group 1, the imported thing(s) in group 2.\n",
-    "_re_loc_import = re.compile(r'(^\\s*)from (\\.\\S*) import (.*)$')\n",
-    "_re_loc_import1 = re.compile(r'(^\\s*)import (\\.\\S*)(.*)$')"
+    "_re_loc_import = re.compile(r'(\\s*)from(\\s+)(\\.\\S*)(\\s+)import(\\s+)(.*)$')\n",
+    "_re_loc_import1 = re.compile(r'(\\s*)import(\\s+)(\\.\\S*)(.*)$')"
    ]
   },
   {
@@ -311,11 +311,11 @@
     "#export\n",
     "def _deal_loc_import(code, fname):\n",
     "    def _replace(m):\n",
-    "        sp,mod,obj = m.groups()\n",
-    "        return f\"{sp}from {relimport2name(mod, fname)} import {obj}\"\n",
+    "        s1,s2,mod,s3,s4,obj = m.groups()\n",
+    "        return f\"{s1}from{s2}{relimport2name(mod, fname)}{s3}import{s4}{obj}\"\n",
     "    def _replace1(m):\n",
-    "        sp,mod,end = m.groups()\n",
-    "        return f\"{sp}import {relimport2name(mod, fname)}{end}\"\n",
+    "        s1,s2,mod,end = m.groups()\n",
+    "        return f\"{s1}import{s2}{relimport2name(mod, fname)}{end}\"\n",
     "    return '\\n'.join([_re_loc_import1.sub(_replace1, _re_loc_import.sub(_replace,line)) for line in code.split('\\n')])"
    ]
   },
@@ -326,10 +326,16 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "code = \"from .core import *\\nnothing to see\\n  from .vision import bla1, bla2\\nimport .vision\\nimport .utils as u\"\n",
-    "test_eq(_deal_loc_import(code, 'nbdev/data.py'), \"\"\"from nbdev.core import *\n",
+    "code = \\\n",
+    "\"\"\"from  .core   import *\n",
     "nothing to see\n",
-    "  from nbdev.vision import bla1, bla2\n",
+    "  \\t from \\t .vision \\t import \\t bla1, \\rbla2\n",
+    "import .vision\n",
+    "import .utils as u\"\"\"\n",
+    "test_eq(_deal_loc_import(code, 'nbdev/data.py'), \n",
+    "\"\"\"from  nbdev.core   import *\n",
+    "nothing to see\n",
+    "  \\t from \\t nbdev.vision \\t import \\t bla1, \\rbla2\n",
     "import nbdev.vision\n",
     "import nbdev.utils as u\"\"\")"
    ]
@@ -570,6 +576,7 @@
       "Converted 06_cli.ipynb.\n",
       "Converted 07_clean.ipynb.\n",
       "Converted 99_search.ipynb.\n",
+      "Converted example.ipynb.\n",
       "Converted index.ipynb.\n",
       "Converted tutorial.ipynb.\n"
      ]


### PR DESCRIPTION
current nbdev parsing does not handle cases where the import are as follow:
```
from lib.a    import *
from lib.bla import c
```
The reason being that the custom spacing after `lib.a` is not supported in the regex.

Added multi-space to the regex, and added test for verification.