### PR TITLE
Specified encoding as utf-8

### DIFF
--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -580,7 +580,7 @@ def convert_md(fname, dest_path, img_path='docs/images/', jekyll=True):
     md = export[0]
     for ext in ['png', 'svg']:
         md = re.sub(r'!\['+ext+'\]\((.+)\)', '!['+ext+'](' + img_path + '\\1)', md)
-    with (Path(dest_path)/dest_name).open('w') as f: f.write(md)
+    with (Path(dest_path)/dest_name).open('w', encoding='utf8') as f: f.write(md)
     if hasattr(export[1]['outputs'], 'items'):
         for n,o in export[1]['outputs'].items():
             with open(Path(dest_path)/img_path/n, 'wb') as f: f.write(o)

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -1924,7 +1924,7 @@
     "    md = export[0]\n",
     "    for ext in ['png', 'svg']:\n",
     "        md = re.sub(r'!\\['+ext+'\\]\\((.+)\\)', '!['+ext+'](' + img_path + '\\\\1)', md)\n",
-    "    with (Path(dest_path)/dest_name).open('w') as f: f.write(md)\n",
+    "    with (Path(dest_path)/dest_name).open('w', encoding='utf8') as f: f.write(md)\n",
     "    if hasattr(export[1]['outputs'], 'items'):\n",
     "        for n,o in export[1]['outputs'].items():\n",
     "            with open(Path(dest_path)/img_path/n, 'wb') as f: f.write(o)"


### PR DESCRIPTION
Currently the conversion to md fails if you have a representation of an Xarray Dataset/DataArray in your nb, this is because of a small arrow character: '\u25ba'.

![image](https://user-images.githubusercontent.com/29051639/102011918-3799ea80-3d3f-11eb-8615-bd48f2cffa63.png)

This change specifies to use utf-8 when opening the notebooks which solves this problem.


Previous error:
```python
~\anaconda3\envs\DataHub\lib\site-packages\nbdev\export2html.py in convert_md(fname, dest_path, img_path, jekyll)
    575     for ext in ['png', 'svg']:
    576         md = re.sub(r'!\['+ext+'\]\((.+)\)', '!['+ext+'](' + img_path + '\\1)', md)
--> 577     with (Path(dest_path)/dest_name).open('w') as f: f.write(md)
    578     if hasattr(export[1]['outputs'], 'items'):
    579         for n,o in export[1]['outputs'].items():

~\anaconda3\envs\DataHub\lib\encodings\cp1252.py in encode(self, input, final)
     17 class IncrementalEncoder(codecs.IncrementalEncoder):
     18     def encode(self, input, final=False):
---> 19         return codecs.charmap_encode(input,self.errors,encoding_table)[0]
     20 
     21 class IncrementalDecoder(codecs.IncrementalDecoder):

UnicodeEncodeError: 'charmap' codec can't encode character '\u25ba' in position 8451: character maps to <undefined>
```