### PR TITLE
change help string and raise error if wrong input

### DIFF
--- a/nbdev/sync.py
+++ b/nbdev/sync.py
@@ -119,9 +119,10 @@ def _script2notebook(fname, dic, silent=False):
 
 # Cell
 @call_parse
-def nbdev_update_lib(fname:Param("A notebook name or glob to convert", str)=None,
+def nbdev_update_lib(fname:Param("A python filename or glob to convert", str)=None,
                      silent:Param("Don't print results", bool_arg)=False):
     "Propagates any change in the modules matching `fname` to the notebooks that created them"
+    if fname.endswith('.ipynb'): raise ValueError("`nbdev_update_lib` operates on .py files.  If you wish to convert notebooks instead, see `nbdev_build_lib`.")
     if os.environ.get('IN_TEST',0): return
     dic = notebook2script(silent=True, to_dict=True)
     exported = get_nbdev_module().modules

--- a/nbs/01_sync.ipynb
+++ b/nbs/01_sync.ipynb
@@ -404,13 +404,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[JupyterApp] WARNING | Config option `kernel_spec_manager_class` not recognized by `JupyterApp`.\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -432,9 +425,10 @@
    "source": [
     "#export\n",
     "@call_parse\n",
-    "def nbdev_update_lib(fname:Param(\"A notebook name or glob to convert\", str)=None,\n",
+    "def nbdev_update_lib(fname:Param(\"A python filename or glob to convert\", str)=None,\n",
     "                     silent:Param(\"Don't print results\", bool_arg)=False):\n",
     "    \"Propagates any change in the modules matching `fname` to the notebooks that created them\"\n",
+    "    if fname.endswith('.ipynb'): raise ValueError(\"`nbdev_update_lib` operates on .py files.  If you wish to convert notebooks instead, see `nbdev_build_lib`.\")\n",
     "    if os.environ.get('IN_TEST',0): return\n",
     "    dic = notebook2script(silent=True, to_dict=True)\n",
     "    exported = get_nbdev_module().modules\n",


### PR DESCRIPTION
This closes #341 

The issue is that understandably some folks are using `nbdev_update_lib` to convert notebooks when they should be using `nbdev_build_lib`.  I made the following changes:

1. Changed the help docs of the CLI because it was wrong:
   - was "A notebook name or glob to convert"
   - changed to "A python filename or glob to convert"

2. Raise a warning if you try to pass in a file or glob ending with `.ipynb` as an argument to `nbdev_update_lib`

@jph00 ready for review