### PR TITLE
added examples of #export

### DIFF
--- a/nbs/00_export.ipynb
+++ b/nbs/00_export.ipynb
@@ -56,6 +56,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Examples of `export`\n",
+    "\n",
+    "See [these examples](https://github.com/fastai/nbdev_export_demo/blob/master/demo.ipynb) on different ways to use `#export` to export code in notebooks to modules.  These include:\n",
+    "\n",
+    "- How to specify a default for exporting cells\n",
+    "- How to hide code and not export it at all\n",
+    "- How to export different cells to specific modules"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Basic foundations"
    ]
   },


### PR DESCRIPTION
Closes #332 

@jph00 I believe how to use `#export` is best demonstrated by example, so I linked to an external notebook where this is demonstrated.  LMK what you think. 

(It is a bit tricky to show export without actually exporting this is why I used an external repo)