### PR TITLE
nbdev_new: get template from latest release asset

### DIFF
--- a/nbs/06_cli.ipynb
+++ b/nbs/06_cli.ipynb
@@ -75,9 +75,9 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"nbdev_build_lib\" class=\"doc_header\"><code>nbdev_build_lib</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export2html.py#L474\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"nbdev_build_lib\" class=\"doc_header\"><code>nbdev_build_lib</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export2html.py#L479\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
-       "> <code>nbdev_build_lib</code>(**`fname`**:\"A notebook name or glob to convert\"=*`None`*)\n",
+       "> <code>nbdev_build_lib</code>(**`fname`**:\"A notebook name or glob to convert\"=*`None`*, **`bare`**:\"Omit nbdev annotation comments (may break some functionality).\"=*`False`*)\n",
        "\n",
        "Export notebooks matching `fname` to python modules"
       ],
@@ -110,7 +110,7 @@
       "text/markdown": [
        "<h4 id=\"nbdev_update_lib\" class=\"doc_header\"><code>nbdev_update_lib</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/sync.py#L121\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
-       "> <code>nbdev_update_lib</code>(**`fname`**:\"A notebook name or glob to convert\"=*`None`*, **`silent`**:\"Don't print results\"=*`False`*)\n",
+       "> <code>nbdev_update_lib</code>(**`fname`**:\"A python filename or glob to convert\"=*`None`*, **`silent`**:\"Don't print results\"=*`False`*)\n",
        "\n",
        "Propagates any change in the modules matching `fname` to the notebooks that created them"
       ],
@@ -214,7 +214,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"nbdev_build_docs\" class=\"doc_header\"><code>nbdev_build_docs</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export2html.py#L652\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"nbdev_build_docs\" class=\"doc_header\"><code>nbdev_build_docs</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export2html.py#L657\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>nbdev_build_docs</code>(**`fname`**:\"A notebook name or glob to convert\"=*`None`*, **`force_all`**:\"Rebuild even notebooks that haven't changed\"=*`False`*, **`mk_readme`**:\"Also convert the index notebook to README\"=*`True`*, **`n_workers`**:\"Number of workers to use\"=*`None`*, **`pause`**:\"Pause time (in secs) between notebooks to avoid race conditions\"=*`0.5`*)\n",
        "\n",
@@ -247,7 +247,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"nbdev_nb2md\" class=\"doc_header\"><code>nbdev_nb2md</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export2html.py#L664\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"nbdev_nb2md\" class=\"doc_header\"><code>nbdev_nb2md</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export2html.py#L669\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>nbdev_nb2md</code>(**`fname`**:\"A notebook file name to convert\", **`dest`**:\"The destination folder\"=*`'.'`*, **`img_path`**:\"Folder to export images to\"=*`''`*, **`jekyll`**:\"To use jekyll metadata for your markdown file or not\"=*`False`*)\n",
        "\n",
@@ -273,7 +273,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"nbdev_detach\" class=\"doc_header\"><code>nbdev_detach</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export2html.py#L616\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"nbdev_detach\" class=\"doc_header\"><code>nbdev_detach</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export2html.py#L621\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>nbdev_detach</code>(**`path_nb`**:\"Path to notebook\", **`dest`**:\"Destination folder\"=*`''`*, **`use_img`**:\"Convert markdown images to img tags\"=*`False`*, **`replace`**:\"Write replacement notebook back to `path_bn`\"=*`True`*)\n",
        "\n",
@@ -306,7 +306,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"nbdev_read_nbs\" class=\"doc_header\"><code>nbdev_read_nbs</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/test.py#L127\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"nbdev_read_nbs\" class=\"doc_header\"><code>nbdev_read_nbs</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/test.py#L125\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>nbdev_read_nbs</code>(**`fname`**:\"A notebook name or glob to convert\"=*`None`*)\n",
        "\n",
@@ -339,7 +339,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"nbdev_trust_nbs\" class=\"doc_header\"><code>nbdev_trust_nbs</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/sync.py#L155\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"nbdev_trust_nbs\" class=\"doc_header\"><code>nbdev_trust_nbs</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/sync.py#L156\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>nbdev_trust_nbs</code>(**`fname`**:\"A notebook name or glob to convert\"=*`None`*, **`force_all`**:\"Trust even notebooks that haven't changed\"=*`False`*)\n",
        "\n",
@@ -557,27 +557,25 @@
     "    if not (author and email): raise Exception('User name and email not configured in git')\n",
     "\n",
     "    # download and untar template, and optionally notebooks\n",
-    "    FILES_URL = 'https://files.fast.ai/files/'\n",
-    "    extract_tgz(f'{FILES_URL}nbdev_files.tgz')\n",
+    "    tgnm = urljson('https://api.github.com/repos/fastai/nbdev_template/releases/latest')['tag_name']\n",
+    "    FILES_URL = f\"https://github.com/fastai/nbdev_template/archive/{tgnm}.tar.gz\"\n",
+    "    extract_tgz(FILES_URL)\n",
     "    path = Path()\n",
-    "    for o in (path/'nbdev_files').ls(): \n",
-    "        if not Path(f'./{o.name}').exists(): shutil.move(str(o), './') \n",
-    "    shutil.rmtree('nbdev_files')\n",
-    "    if first(path.glob('*.ipynb')): print(\"00_core.ipynb not downloaded since a notebook already exists.\")\n",
-    "    else: urlsave(f'{FILES_URL}00_core.ipynb')\n",
-    "    if not (path/'index.ipynb').exists(): urlsave(f'{FILES_URL}index.ipynb')\n",
+    "    nbexists = True if first(path.glob('*.ipynb')) else False\n",
+    "    for o in (path/f'nbdev_template-{tgnm}').ls(): \n",
+    "        if o.name == '00_core.ipynb':\n",
+    "            if not nbexists: shutil.move(str(o), './')\n",
+    "        elif not Path(f'./{o.name}').exists(): shutil.move(str(o), './') \n",
+    "    shutil.rmtree(f'nbdev_template-{tgnm}')\n",
     "\n",
     "    # auto-config settings.ini from git\n",
     "    settings_path = Path('settings.ini')\n",
     "    settings = settings_path.read_text()\n",
     "    owner,repo = repo_details(url)\n",
-    "    branch = run('git symbolic-ref refs/remotes/origin/HEAD').strip().split('/')[-1]\n",
+    "    branch = urljson('https://api.github.com/repos/fastai/nbdev_template')['default_branch']\n",
     "    settings = settings.format(lib_name=repo, user=owner, author=author, author_email=email, branch=branch)\n",
-    "    settings_path.write_text(settings)\n",
-    "    \n",
-    "    nbdev_install_git_hooks()\n",
-    "    if not (path/'LICENSE').exists() and not (path/'LICENSE.md').exists():\n",
-    "        warnings.warn('No LICENSE file found - you will need one if you will create pypi or conda packages.')"
+    "    settings_path.write_text(settings)    \n",
+    "    nbdev_install_git_hooks()"
    ]
   },
   {
@@ -616,7 +614,6 @@
       "Converted 99_search.ipynb.\n",
       "Converted example.ipynb.\n",
       "Converted index.ipynb.\n",
-      "Converted try_save.ipynb.\n",
       "Converted tutorial.ipynb.\n"
      ]
     }


### PR DESCRIPTION
Changes made

- Instead of files.fast.ai, we get nbdev template files from the latest release asset files of fastai/nbdev_template
- Get branch name from the github api

I tested this locally with multiple scenarios (new repos, existing repo, when files are present, when they aren't present, etc). 

closes #383 

@jph00 ready for review