### PR TITLE
extend test timeout for windows

### DIFF
--- a/nbdev/test.py
+++ b/nbdev/test.py
@@ -79,7 +79,8 @@ def test_nb(fn, flags=None):
         nb = read_nb(fn)
         for f in get_all_flags(nb['cells']):
             if f not in flags: return
-        ep = NoExportPreprocessor(flags, timeout=600, kernel_name='python3')
+        timeout = 1800 if sys.platform == "win32" else 600
+        ep = NoExportPreprocessor(flags, timeout=timeout, kernel_name='python3')
         pnb = nbformat.from_dict(nb)
         ep.preprocess(pnb)
     finally: os.environ.pop("IN_TEST")

--- a/nbs/04_test.ipynb
+++ b/nbs/04_test.ipynb
@@ -265,7 +265,8 @@
     "        nb = read_nb(fn)\n",
     "        for f in get_all_flags(nb['cells']):\n",
     "            if f not in flags: return\n",
-    "        ep = NoExportPreprocessor(flags, timeout=600, kernel_name='python3')\n",
+    "        timeout = 1800 if sys.platform == \"win32\" else 600\n",
+    "        ep = NoExportPreprocessor(flags, timeout=timeout, kernel_name='python3')\n",
     "        pnb = nbformat.from_dict(nb)\n",
     "        ep.preprocess(pnb)\n",
     "    finally: os.environ.pop(\"IN_TEST\")"
@@ -377,7 +378,8 @@
       "Converted 99_search.ipynb.\n",
       "Converted example.ipynb.\n",
       "Converted index.ipynb.\n",
-      "Converted tutorial.ipynb.\n"
+      "Converted tutorial.ipynb.\n",
+      "Converted tutorial_colab.ipynb.\n"
      ]
     }
    ],


### PR DESCRIPTION
Since we have to use single process in notebook on Windows, some operations take longer time.
For example , the below takes 10 more minutes.
https://github.com/fastai/fastai/blob/master/nbs/14_callback.schedule.ipynb
![image](https://user-images.githubusercontent.com/16190118/106621246-584b2780-65ad-11eb-8bf3-a93041750f3c.png)



