### PR TITLE
Pin Jupyter client version to avoid coroutine error 

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ status = 4
 min_python = 3.6
 audience = Developers
 language = English
-requirements = fastcore>=1.3.19 nbformat>=4.4.0 nbconvert<6 pyyaml jupyter_client jupyter ipykernel ghapi fastrelease
+requirements = fastcore>=1.3.19 nbformat>=4.4.0 nbconvert<6 pyyaml jupyter-client=6.1.12 jupyter ipykernel ghapi fastrelease
 console_scripts = nbdev_build_lib=nbdev.export2html:nbdev_build_lib
 	nbdev_update_lib=nbdev.sync:nbdev_update_lib
 	nbdev_diff_nbs=nbdev.sync:nbdev_diff_nbs

--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ status = 4
 min_python = 3.6
 audience = Developers
 language = English
-requirements = fastcore>=1.3.19 nbformat>=4.4.0 nbconvert<6 pyyaml jupyter-client=6.1.12 jupyter ipykernel ghapi fastrelease
+requirements = fastcore>=1.3.19 nbformat>=4.4.0 nbconvert<6 pyyaml jupyter-client==6.1.12 jupyter ipykernel ghapi fastrelease
 console_scripts = nbdev_build_lib=nbdev.export2html:nbdev_build_lib
 	nbdev_update_lib=nbdev.sync:nbdev_update_lib
 	nbdev_diff_nbs=nbdev.sync:nbdev_diff_nbs


### PR DESCRIPTION
Pin Jupyter client at prior version to fix #454 #456 temporarily.  

We probably need to figure out a long-term solution, however.  cc: @jph00 