### PR TITLE
Add reference to the fastcore tests in the Extract tests tab

### DIFF
--- a/docs/test.html
+++ b/docs/test.html
@@ -38,6 +38,13 @@ nb_path: "nbs/04_test.ipynb"
 
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
+<p>{% include important.html content='The testing utilities themselves are provided by <a href="https://fastcore.fast.ai/test.html">fastcore&#8217;s testing utilities</a>, which provide wrappers around common types of assert statements and also provide better default error messages.' %}</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
 <p>Everything that is not an exported cell is considered a test, so you should make sure your notebooks can all run smoothly (and fast) if you want to use this functionality as the CLI. You can mark some cells with special flags (like slow) to make sure they are only executed when you authorize it. Those flags should be configured in your <code>settings.ini</code> (separated by a <code>|</code> if you have several of them). You can also apply flags to one entire notebook by using the <code>all</code> option, e.g. <code>#all_slow</code>, in code cells.</p>
 <p>If <code>tst_flags=slow|fastai</code> in <code>settings.ini</code>, you can:</p>
 <ul>

--- a/nbs/04_test.ipynb
+++ b/nbs/04_test.ipynb
@@ -44,6 +44,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> Important: The testing utilities themselves are provided by [fastcore's testing utilities](https://fastcore.fast.ai/test.html), which provide wrappers around common types of assert statements and also provide better default error messages."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Everything that is not an exported cell is considered a test, so you should make sure your notebooks can all run smoothly (and fast) if you want to use this functionality as the CLI. You can mark some cells with special flags (like slow) to make sure they are only executed when you authorize it. Those flags should be configured in your `settings.ini` (separated by a `|` if you have several of them). You can also apply flags to one entire notebook by using the `all` option, e.g. `#all_slow`, in code cells.\n",
     "\n",
     "If `tst_flags=slow|fastai` in `settings.ini`, you can:\n",


### PR DESCRIPTION
Fixes issue #517


As somebody who is just learning nbdev, I was trying to figure out where nbdev testing functions come from, specifically `test_eq()`. So I went to the nbdev docs and clicked the first tab that has **test**,  on it and to my surprise did not find the `test_eq` function definition. After some exploration I discovered the tests are actually defined in [fastcore](https://fastcore.fast.ai/test.html), but this was not obvious. This PR adds a link on the nbdev testing page to the fastcore testing page to make this relationship more obvious.

**Before:**
![before](https://user-images.githubusercontent.com/8211563/129294382-5cb9b9f8-cb17-493b-85b7-88822cdb586b.png)

**After:**
![after](https://user-images.githubusercontent.com/8211563/129294404-41c0c7c6-c917-402d-b08c-8e6be1d26b81.png)
