### PR TITLE
Update path to _config.yml in tutorial

### DIFF
--- a/nbs/tutorial.ipynb
+++ b/nbs/tutorial.ipynb
@@ -884,7 +884,7 @@
    "source": [
     "Because both the documentation and code for nbdev is written in notebooks, you can optionally view and run nbdev documentation in [Google Colab](https://colab.research.google.com/). You can enable Google Colab badges that link to the appropriate notebook(s) in your GitHub repository.  \n",
     "\n",
-    "You can toggle this feature on or off in your `/_config.yml` file:\n",
+    "You can toggle this feature on or off in your `docs/_config.yml` file:\n",
     "\n",
     "```yaml\n",
     "# This specifies what badges are turned on by default for notebook docs.\n",


### PR DESCRIPTION
Current version of tutorial shows path to `_config.yml` file in root directory. The config file is stored in the `docs` directory.

This PR fixes the path to the file in the tutorial.