### PR TITLE
updating tutorial instructions for github UI change

### DIFF
--- a/nbs/tutorial.ipynb
+++ b/nbs/tutorial.ipynb
@@ -132,7 +132,7 @@
    "source": [
     "The nbdev system uses [jekyll](https://jekyllrb.com/) for documentation. Because [GitHub Pages supports Jekyll](https://help.github.com/en/github/working-with-github-pages/setting-up-a-github-pages-site-with-jekyll), you can host your site for free on [Github Pages](https://pages.github.com/) without any additional setup, so this is the approach we recommend (but it's not required; any jekyll hosting will work fine).\n",
     "\n",
-    "To enable Github Pages in your project repo, click *Settings* in Github, then scroll down to *Github Pages*, and set \"Source\" to *Master branch /docs folder*. Once you've saved, if you scroll back down to that section, Github will have a link to your new website. Copy that URL, and then go back to your main repo page, click \"edit\" next to the description and paste the URL into the \"website\" section. While you're there, go ahead and put in your project description too. *NOTE: Don't expect your Pages to build & deploy properly yet; only after we edit `settings.ini` (below) and make some other changes will your GitHub Pages site be deployed.*\n",
+    "To enable Github Pages in your project repo, click *Settings* in Github, then click *Pages* on the left side bar.  Set \"Source\" to *Master branch /docs folder*. Once you've saved, if you refresh that page, Github will have a link to your new website. Copy that URL, and then go back to your main repo page, click \"edit\" next to the description and paste the URL into the \"website\" section. While you're there, go ahead and put in your project description too. *NOTE: Don't expect your Pages to build & deploy properly yet; only after we edit `settings.ini` (below) and make some other changes will your GitHub Pages site be deployed.*\n",
     "\n",
     "#### Previewing Documents Locally \n",
     "\n",
@@ -943,11 +943,11 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Github Page settings were moved and this reflects that change in the tutorial.  

There's currently a link to the new location where Pages settings used to be - though no idea how long they plan to leave that in the UI.

I am also unsure of if there is anywhere else other than the tutorial this change should be made.