### PR TITLE
Make relative imports configurable

### DIFF
--- a/nbs/00_export.ipynb
+++ b/nbs/00_export.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "hide_input": false
    },
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "hide_input": false
    },
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -189,7 +189,7 @@
        "dict_keys(['cells', 'metadata', 'nbformat', 'nbformat_minor'])"
       ]
      },
-     "execution_count": 7,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -200,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -219,7 +219,7 @@
        "  'version': '3.6.13'}}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -230,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -239,7 +239,7 @@
        "'4.4'"
       ]
      },
-     "execution_count": 9,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -257,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -276,7 +276,7 @@
        " 'source': '#hide\\n#default_exp export\\n#default_cls_lvl 3\\nfrom nbdev.showdoc import show_doc'}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -301,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -366,7 +366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,7 +402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -426,7 +426,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,7 +437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,7 +448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -459,7 +459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,7 +471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -506,7 +506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -543,7 +543,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -553,7 +553,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -573,7 +573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -583,7 +583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -609,7 +609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -635,7 +635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -645,7 +645,7 @@
        " ('func', 'Class', None))"
       ]
      },
-     "execution_count": 29,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -660,7 +660,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -696,7 +696,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -715,7 +715,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -727,7 +727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -745,7 +745,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -758,7 +758,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -774,7 +774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -790,7 +790,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -826,7 +826,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -835,7 +835,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -883,7 +883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -903,7 +903,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -932,7 +932,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -962,7 +962,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -999,7 +999,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1042,7 +1042,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1074,7 +1074,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1091,7 +1091,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1112,7 +1112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1154,7 +1154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1167,7 +1167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1177,7 +1177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1192,7 +1192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1241,7 +1241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1251,7 +1251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1277,7 +1277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1292,7 +1292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1309,7 +1309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1320,7 +1320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1338,7 +1338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1371,7 +1371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1407,7 +1407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1425,7 +1425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1451,7 +1451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1497,7 +1497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1545,7 +1545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1565,7 +1565,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1576,7 +1576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1592,7 +1592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1609,7 +1609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1619,7 +1619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1637,7 +1637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1647,7 +1647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1664,7 +1664,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1690,7 +1690,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1715,7 +1715,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1727,7 +1727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1736,7 +1736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1759,7 +1759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1770,7 +1770,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1802,7 +1802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1814,7 +1814,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1833,7 +1833,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1878,27 +1878,12 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "681c92f4b52721dd49a132046a1d84c838c0959341ffbf992005d8c8adf8e185"
-  },
   "jupytext": {
    "split_at_heading": true
   },
   "kernelspec": {
    "display_name": "Python 3.6.13 64-bit ('nbdev_contribute': conda)",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.13"
   }
  },
  "nbformat": 4,

--- a/nbs/00_export.ipynb
+++ b/nbs/00_export.ipynb
@@ -2,11 +2,23 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "hide_input": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ImportError",
+     "evalue": "cannot import name 'show_doc'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-3-f048ca53a696>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;31m#default_exp export\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;31m#default_cls_lvl 3\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mnbdev\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshowdoc\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mshow_doc\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m: cannot import name 'show_doc'"
+     ]
+    }
+   ],
    "source": [
     "#hide\n",
     "#default_exp export\n",
@@ -87,7 +99,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"Config\" class=\"doc_header\"><code>class</code> <code>Config</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L249\" class=\"source_link\" style=\"float:right\">[source]</a></h3>\n",
+       "<h3 id=\"Config\" class=\"doc_header\"><code>class</code> <code>Config</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L250\" class=\"source_link\" style=\"float:right\">[source]</a></h3>\n",
        "\n",
        "> <code>Config</code>(**`cfg_path`**, **`cfg_name`**, **`create`**=*`None`*)\n",
        "\n",
@@ -189,7 +201,7 @@
        "dict_keys(['cells', 'metadata', 'nbformat', 'nbformat_minor'])"
       ]
      },
-     "execution_count": null,
+     "execution_count": 147,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -206,9 +218,9 @@
     {
      "data": {
       "text/plain": [
-       "{'jupytext': {'split_at_heading': True},\n",
-       " 'kernelspec': {'display_name': 'Python 3',\n",
-       "  'language': 'python',\n",
+       "{'interpreter': {'hash': '681c92f4b52721dd49a132046a1d84c838c0959341ffbf992005d8c8adf8e185'},\n",
+       " 'jupytext': {'split_at_heading': True},\n",
+       " 'kernelspec': {'display_name': \"Python 3.6.13 64-bit ('nbdev_contribute': conda)\",\n",
        "  'name': 'python3'},\n",
        " 'language_info': {'codemirror_mode': {'name': 'ipython', 'version': 3},\n",
        "  'file_extension': '.py',\n",
@@ -216,21 +228,10 @@
        "  'name': 'python',\n",
        "  'nbconvert_exporter': 'python',\n",
        "  'pygments_lexer': 'ipython3',\n",
-       "  'version': '3.8.10'},\n",
-       " 'toc': {'base_numbering': 1,\n",
-       "  'nav_menu': {},\n",
-       "  'number_sections': False,\n",
-       "  'sideBar': True,\n",
-       "  'skip_h1_title': True,\n",
-       "  'title_cell': 'Table of Contents',\n",
-       "  'title_sidebar': 'Contents',\n",
-       "  'toc_cell': False,\n",
-       "  'toc_position': {},\n",
-       "  'toc_section_display': True,\n",
-       "  'toc_window_display': False}}"
+       "  'version': '3.6.13'}}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 148,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -250,7 +251,7 @@
        "'4.4'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 149,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -275,13 +276,13 @@
      "data": {
       "text/plain": [
        "{'cell_type': 'code',\n",
-       " 'execution_count': 1,\n",
+       " 'execution_count': 110,\n",
        " 'metadata': {'hide_input': False},\n",
        " 'outputs': [],\n",
        " 'source': '#hide\\n#default_exp export\\n#default_cls_lvl 3\\nfrom nbdev.showdoc import show_doc'}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 150,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -331,7 +332,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-152-8e15ed75d114>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mcell\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtest_nb\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'cells'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcopy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;32massert\u001b[0m \u001b[0mcheck_re\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'#export'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0;32massert\u001b[0m \u001b[0mcheck_re\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mre\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcompile\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'#export'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;32massert\u001b[0m \u001b[0mcheck_re\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'# bla'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mcell\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'cell_type'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'markdown'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: "
+     ]
+    }
+   ],
    "source": [
     "cell = test_nb['cells'][1].copy()\n",
     "assert check_re(cell, '#export') is not None\n",
@@ -646,11 +659,11 @@
     {
      "data": {
       "text/plain": [
-       "(<re.Match object; span=(1, 42), match='@patch\\n@log_args(a=1)\\ndef func(obj:Class)'>,\n",
+       "(<_sre.SRE_Match object; span=(1, 42), match='@patch\\n@log_args(a=1)\\ndef func(obj:Class)'>,\n",
        " ('func', 'Class', None))"
       ]
      },
-     "execution_count": null,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1187,10 +1200,11 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def _deal_import(code_lines, fname):\n",
+    "def _deal_import(code_lines, fname, absolute_imports):\n",
     "    def _replace(m):\n",
     "        sp,mod,obj = m.groups()\n",
     "        return f\"{sp}from {relative_import(mod, fname)} import {obj}\"\n",
+    "    if absolute_imports: return code_lines\n",
     "    return [_re_import.re.sub(_replace,line) for line in code_lines]"
    ]
   },
@@ -1198,7 +1212,17 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " nbdev.core *\n",
+      "   nbdev.vision bla1, bla2\n",
+      " nbdev.vision models\n"
+     ]
+    }
+   ],
    "source": [
     "#hide\n",
     "lines = [\"from nbdev.core import *\", \n",
@@ -1206,11 +1230,18 @@
     "         \"  from nbdev.vision import bla1, bla2\", \n",
     "         \"from nbdev.vision import models\",\n",
     "         \"import nbdev.vision\"]\n",
-    "test_eq(_deal_import(lines, Path.cwd()/'nbdev'/'data.py'), [\n",
+    "test_eq(_deal_import(lines, Path.cwd()/'nbdev'/'data.py', False), [\n",
     "    \"from .core import *\", \n",
     "    \"nothing to see\", \n",
     "    \"  from .vision import bla1, bla2\", \n",
     "    \"from .vision import models\",\n",
+    "    \"import nbdev.vision\"\n",
+    "])\n",
+    "test_eq(_deal_import(lines, Path.cwd()/'nbdev'/'data.py', True), [\n",
+    "    \"from nbdev.core import *\", \n",
+    "    \"nothing to see\", \n",
+    "    \"  from nbdev.vision import bla1, bla2\", \n",
+    "    \"from nbdev.vision import models\",\n",
     "    \"import nbdev.vision\"\n",
     "])"
    ]
@@ -1501,6 +1532,7 @@
     "#export\n",
     "def _notebook2script(fname, modules, silent=False, to_dict=None, bare=False):\n",
     "    \"Finds cells starting with `#export` and puts them into a module created by `create_mod_files`\"\n",
+    "    absolute_imports = (get_config().get('absolute_imports') == 'True')\n",
     "    bare = str(get_config().get('bare', bare)) == 'True'\n",
     "    if os.environ.get('IN_TEST',0): return  # don't export if running tests\n",
     "    sep = '\\n'* (int(get_config().get('cell_spacing', '1'))+1)\n",
@@ -1518,7 +1550,7 @@
     "        if bare: orig = \"\\n\"\n",
     "        else: orig = (f'# {\"\" if a else \"Internal \"}C' if e==default else f'# Comes from {fname.name}, c') + 'ell\\n'\n",
     "        flag_lines,code_lines = split_flags_and_code(c)\n",
-    "        code_lines = _deal_import(code_lines, fname_out)\n",
+    "        code_lines = _deal_import(code_lines, fname_out, absolute_imports)\n",
     "        code = sep + orig + '\\n'.join(code_lines)\n",
     "        names = export_names(code)\n",
     "        flags = '\\n'.join(flag_lines)\n",
@@ -1548,6 +1580,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "False\n",
       "Converted 00_export.ipynb.\n"
      ]
     }
@@ -1831,7 +1864,42 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\n",
+      "Converted 00_export.ipynb.\n",
+      "False\n",
+      "Converted 01_sync.ipynb.\n",
+      "False\n",
+      "Converted 02_showdoc.ipynb.\n",
+      "False\n",
+      "Converted 03_export2html.ipynb.\n",
+      "False\n",
+      "Converted 04_test.ipynb.\n",
+      "False\n",
+      "Converted 05_merge.ipynb.\n",
+      "False\n",
+      "Converted 06_cli.ipynb.\n",
+      "False\n",
+      "Converted 07_clean.ipynb.\n",
+      "False\n",
+      "Converted 99_search.ipynb.\n",
+      "False\n",
+      "Converted example.ipynb.\n",
+      "False\n",
+      "Converted index.ipynb.\n",
+      "False\n",
+      "Converted nbdev_comments.ipynb.\n",
+      "False\n",
+      "Converted tutorial.ipynb.\n",
+      "False\n",
+      "Converted tutorial_colab.ipynb.\n"
+     ]
+    }
+   ],
    "source": [
     "#hide\n",
     "notebook2script()"
@@ -1846,13 +1914,27 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "681c92f4b52721dd49a132046a1d84c838c0959341ffbf992005d8c8adf8e185"
+  },
   "jupytext": {
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "Python 3.6.13 64-bit ('nbdev_contribute': conda)",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,

--- a/nbs/00_export.ipynb
+++ b/nbs/00_export.ipynb
@@ -2,23 +2,11 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {
     "hide_input": false
    },
-   "outputs": [
-    {
-     "ename": "ImportError",
-     "evalue": "cannot import name 'show_doc'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-3-f048ca53a696>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;31m#default_exp export\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;31m#default_cls_lvl 3\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mnbdev\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshowdoc\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mshow_doc\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mImportError\u001b[0m: cannot import name 'show_doc'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#hide\n",
     "#default_exp export\n",
@@ -28,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "hide_input": false
    },
@@ -93,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -119,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -201,7 +189,7 @@
        "dict_keys(['cells', 'metadata', 'nbformat', 'nbformat_minor'])"
       ]
      },
-     "execution_count": 147,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -212,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -231,7 +219,7 @@
        "  'version': '3.6.13'}}"
       ]
      },
-     "execution_count": 148,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -242,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -251,7 +239,7 @@
        "'4.4'"
       ]
      },
-     "execution_count": 149,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -269,20 +257,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{'cell_type': 'code',\n",
-       " 'execution_count': 110,\n",
+       " 'execution_count': 3,\n",
        " 'metadata': {'hide_input': False},\n",
-       " 'outputs': [],\n",
+       " 'outputs': [{'ename': 'ImportError',\n",
+       "   'evalue': \"cannot import name 'show_doc'\",\n",
+       "   'output_type': 'error',\n",
+       "   'traceback': ['\\x1b[0;31m---------------------------------------------------------------------------\\x1b[0m',\n",
+       "    '\\x1b[0;31mImportError\\x1b[0m                               Traceback (most recent call last)',\n",
+       "    '\\x1b[0;32m<ipython-input-3-f048ca53a696>\\x1b[0m in \\x1b[0;36m<module>\\x1b[0;34m\\x1b[0m\\n\\x1b[1;32m      2\\x1b[0m \\x1b[0;31m#default_exp export\\x1b[0m\\x1b[0;34m\\x1b[0m\\x1b[0;34m\\x1b[0m\\x1b[0;34m\\x1b[0m\\x1b[0m\\n\\x1b[1;32m      3\\x1b[0m \\x1b[0;31m#default_cls_lvl 3\\x1b[0m\\x1b[0;34m\\x1b[0m\\x1b[0;34m\\x1b[0m\\x1b[0;34m\\x1b[0m\\x1b[0m\\n\\x1b[0;32m----> 4\\x1b[0;31m \\x1b[0;32mfrom\\x1b[0m \\x1b[0mnbdev\\x1b[0m\\x1b[0;34m.\\x1b[0m\\x1b[0mshowdoc\\x1b[0m \\x1b[0;32mimport\\x1b[0m \\x1b[0mshow_doc\\x1b[0m\\x1b[0;34m\\x1b[0m\\x1b[0;34m\\x1b[0m\\x1b[0m\\n\\x1b[0m',\n",
+       "    \"\\x1b[0;31mImportError\\x1b[0m: cannot import name 'show_doc'\"]}],\n",
        " 'source': '#hide\\n#default_exp export\\n#default_cls_lvl 3\\nfrom nbdev.showdoc import show_doc'}"
       ]
      },
-     "execution_count": 150,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -307,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -330,21 +324,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AssertionError",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-152-8e15ed75d114>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mcell\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtest_nb\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'cells'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcopy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;32massert\u001b[0m \u001b[0mcheck_re\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'#export'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0;32massert\u001b[0m \u001b[0mcheck_re\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mre\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcompile\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'#export'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;32massert\u001b[0m \u001b[0mcheck_re\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'# bla'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mcell\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'cell_type'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'markdown'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAssertionError\u001b[0m: "
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cell = test_nb['cells'][1].copy()\n",
     "assert check_re(cell, '#export') is not None\n",
@@ -357,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -384,7 +366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,7 +402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +426,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,7 +437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,7 +448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,7 +459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,7 +471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -524,7 +506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -540,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,7 +543,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -571,7 +553,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -601,7 +583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -627,7 +609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -653,7 +635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -678,7 +660,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -714,7 +696,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -733,7 +715,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -745,7 +727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -763,7 +745,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -776,7 +758,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -792,7 +774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -808,7 +790,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -844,7 +826,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -853,7 +835,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -901,7 +883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -921,7 +903,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -950,7 +932,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -980,7 +962,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1017,7 +999,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1060,7 +1042,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1092,7 +1074,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1109,7 +1091,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1130,7 +1112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1172,7 +1154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1185,7 +1167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1195,7 +1177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1210,19 +1192,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " nbdev.core *\n",
-      "   nbdev.vision bla1, bla2\n",
-      " nbdev.vision models\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#hide\n",
     "lines = [\"from nbdev.core import *\", \n",
@@ -1269,7 +1241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1279,7 +1251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1305,7 +1277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1320,7 +1292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1337,7 +1309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1348,7 +1320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1366,7 +1338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1399,7 +1371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1435,7 +1407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1453,7 +1425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1479,7 +1451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1525,7 +1497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1573,14 +1545,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "False\n",
       "Converted 00_export.ipynb.\n"
      ]
     }
@@ -1594,7 +1565,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1605,7 +1576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1621,7 +1592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1638,7 +1609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1648,7 +1619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1666,7 +1637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1676,7 +1647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1693,7 +1664,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1719,7 +1690,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1744,7 +1715,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1756,7 +1727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1765,7 +1736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1788,7 +1759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1799,7 +1770,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1831,7 +1802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1843,7 +1814,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1862,40 +1833,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "False\n",
       "Converted 00_export.ipynb.\n",
-      "False\n",
       "Converted 01_sync.ipynb.\n",
-      "False\n",
       "Converted 02_showdoc.ipynb.\n",
-      "False\n",
       "Converted 03_export2html.ipynb.\n",
-      "False\n",
       "Converted 04_test.ipynb.\n",
-      "False\n",
       "Converted 05_merge.ipynb.\n",
-      "False\n",
       "Converted 06_cli.ipynb.\n",
-      "False\n",
       "Converted 07_clean.ipynb.\n",
-      "False\n",
       "Converted 99_search.ipynb.\n",
-      "False\n",
       "Converted example.ipynb.\n",
-      "False\n",
       "Converted index.ipynb.\n",
-      "False\n",
       "Converted nbdev_comments.ipynb.\n",
-      "False\n",
       "Converted tutorial.ipynb.\n",
-      "False\n",
       "Converted tutorial_colab.ipynb.\n"
      ]
     }
@@ -1904,6 +1861,13 @@
     "#hide\n",
     "notebook2script()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/settings.ini
+++ b/settings.ini
@@ -41,4 +41,5 @@ custom_sidebar = True
 recursive = True
 cell_spacing = 1
 monospace_docstrings = False
+absolute_imports = False
 


### PR DESCRIPTION
Using nbdev for my personal projects, I prefer nbdev will convert the notebooks to python scripts with absolute imports instead of relative. It really helps me to run with some other frameworks also.
(Will squash and merge)