### PR TITLE
Replaced IN_NOTEBOOK to fix vscode show_doc error

### DIFF
--- a/nbdev/showdoc.py
+++ b/nbdev/showdoc.py
@@ -9,11 +9,12 @@ from .imports import *
 from .export import *
 from .sync import *
 from nbconvert import HTMLExporter
-from fastcore.utils import IN_NOTEBOOK
 
-if IN_NOTEBOOK:
+try:
     from IPython.display import Markdown,display
     from IPython.core import page
+except ModuleNotFoundError:
+    pass
 
 # Cell
 def is_enum(cls):

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -25,11 +25,12 @@
     "from nbdev.export import *\n",
     "from nbdev.sync import *\n",
     "from nbconvert import HTMLExporter\n",
-    "from fastcore.utils import IN_NOTEBOOK\n",
     "\n",
-    "if IN_NOTEBOOK:\n",
+    "try:\n",
     "    from IPython.display import Markdown,display\n",
-    "    from IPython.core import page"
+    "    from IPython.core import page\n",
+    "except ModuleNotFoundError:\n",
+    "    pass"
    ]
   },
   {
@@ -382,12 +383,12 @@
    "source": [
     "class T:\n",
     "    def __init__(self, add_doc_links): pass\n",
-    "test_eq(add_doc_links('Lets talk about `add_doc_links`'), \n",
+    "test_eq(add_doc_links('Lets talk about `add_doc_links`'),\n",
     "        'Lets talk about [`add_doc_links`](/showdoc.html#add_doc_links)')\n",
     "test_eq(add_doc_links('Lets talk about `add_doc_links`', T), 'Lets talk about `add_doc_links`')\n",
-    "test_eq(add_doc_links('Lets talk about `doc_link`'), \n",
+    "test_eq(add_doc_links('Lets talk about `doc_link`'),\n",
     "        'Lets talk about [`doc_link`](/showdoc.html#doc_link)')\n",
-    "test_eq(add_doc_links('Lets talk about `doc_link`', T), \n",
+    "test_eq(add_doc_links('Lets talk about `doc_link`', T),\n",
     "        'Lets talk about [`doc_link`](/showdoc.html#doc_link)')"
    ]
   },
@@ -777,7 +778,7 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "test_eq(_format_func_doc(notebook2script), ('<code>notebook2script</code>', \n",
+    "test_eq(_format_func_doc(notebook2script), ('<code>notebook2script</code>',\n",
     "'<code>notebook2script</code>(**`fname`**=*`None`*, **`silent`**=*`False`*, **`to_dict`**=*`False`*, **`bare`**=*`False`*)'))"
    ]
   },
@@ -803,7 +804,7 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "test_eq(_format_cls_doc(DocsTestClass, 'DocsTestClass'), ('<code>class</code> <code>DocsTestClass</code>', \n",
+    "test_eq(_format_cls_doc(DocsTestClass, 'DocsTestClass'), ('<code>class</code> <code>DocsTestClass</code>',\n",
     "                                                          '<code>DocsTestClass</code>()'))"
    ]
   },
@@ -866,7 +867,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"notebook2script\" class=\"doc_header\"><code>notebook2script</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L413\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"notebook2script\" class=\"doc_header\"><code>notebook2script</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L419\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>notebook2script</code>(**`fname`**=*`None`*, **`silent`**=*`False`*, **`to_dict`**=*`False`*, **`bare`**=*`False`*)\n",
        "\n",
@@ -914,7 +915,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h2 id=\"DocsTestClass\" class=\"doc_header\"><code>class</code> <code>DocsTestClass</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L429\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\n",
+       "<h2 id=\"DocsTestClass\" class=\"doc_header\"><code>class</code> <code>DocsTestClass</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L435\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\n",
        "\n",
        "> <code>DocsTestClass</code>()\n",
        "\n",
@@ -941,7 +942,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"DocsTestClass.test\" class=\"doc_header\"><code>DocsTestClass.test</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L431\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"DocsTestClass.test\" class=\"doc_header\"><code>DocsTestClass.test</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L437\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>DocsTestClass.test</code>()\n",
        "\n"


### PR DESCRIPTION
This PR fixes https://github.com/fastai/nbdev/issues/580

This is related to [this issue](https://github.com/fastai/fastcore/issues/365) in fastcore where fastcore.utils.IN_NOTEBOOK returns False in vscode, even though in_notebook() returns True.

Removing IN_NOTEBOOK and using a try/except ModuleNotFoundError block seems like a Pythonic way to handle this and fixes the error.