### PR TITLE
Refactor try/catch to be better

### DIFF
--- a/nbdev/export.py
+++ b/nbdev/export.py
@@ -242,7 +242,7 @@ def reset_nbdev_module():
     "Create a skeleton for <code>_nbdev</code>"
     fname = get_config().path("lib_path")/'_nbdev.py'
     fname.parent.mkdir(parents=True, exist_ok=True)
-    sep = '\n'* (int(get_config().get('cell_spacing', '1'))+1)
+    sep = '\n' * (get_config().d.getint('cell_spacing', 1) + 1)
     if fname.is_file():
         with open(fname, 'r') as f: search = _re_index_custom.search(f.read())
     else: search = None
@@ -305,7 +305,7 @@ def split_flags_and_code(cell, return_type=list):
 # Cell
 def create_mod_file(fname, nb_path, bare=False):
     "Create a module file for `fname`."
-    bare = str(get_config().get('bare', bare)) == 'True'
+    bare = get_config().d.getboolean('bare', bare)
     fname.parent.mkdir(parents=True, exist_ok=True)
     file_path = os.path.relpath(nb_path, get_config().config_file.parent).replace('\\', '/')
     with open(fname, 'w') as f:
@@ -330,9 +330,9 @@ def create_mod_files(files, to_dict=False, bare=False):
 # Cell
 def _notebook2script(fname, modules, silent=False, to_dict=None, bare=False):
     "Finds cells starting with `#export` and puts them into a module created by `create_mod_files`"
-    bare = str(get_config().get('bare', bare)) == 'True'
+    bare = get_config().d.getboolean('bare', bare)
     if os.environ.get('IN_TEST',0): return  # don't export if running tests
-    sep = '\n'* (int(get_config().get('cell_spacing', '1'))+1)
+    sep = '\n' * (get_config().d.getint('cell_spacing', 1) + 1)
     fname = Path(fname)
     nb = read_nb(fname)
     default = find_default_export(nb['cells'])

--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -252,8 +252,7 @@ def nb_code_cell(source):
 
 # Cell
 def _show_doc_cell(name, cls_lvl=None):
-    try: show_all = (get_config().get('show_all_docments') == 'True')
-    except: show_all = False
+    show_all = get_config().d.getboolean('show_all_docments', False)
     return nb_code_cell(f"show_doc({name}{'' if cls_lvl is None else f', default_cls_level={cls_lvl}'}, show_all_docments={show_all})")
 
 def add_show_docs(cells, cls_lvl=None):

--- a/nbdev/showdoc.py
+++ b/nbdev/showdoc.py
@@ -362,7 +362,8 @@ def show_doc(elt, doc_string:bool=True, name=None, title_level=None, disp=True, 
     if doc_string and inspect.getdoc(elt):
         s = inspect.getdoc(elt)
         # show_doc is used by doc so should not rely on Config
-        try: monospace = (get_config().get('monospace_docstrings') == 'True')
+        # We use except because `get_config` raises Exception if not found
+        try: monospace = get_config().d.getboolean('monospace_docstrings', False)
         except: monospace = False
         # doc links don't work inside markdown pre/code blocks
         s = f'```\n{s}\n```' if monospace else add_doc_links(s, elt)

--- a/nbs/00_export.ipynb
+++ b/nbs/00_export.ipynb
@@ -87,7 +87,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"Config\" class=\"doc_header\"><code>class</code> <code>Config</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L249\" class=\"source_link\" style=\"float:right\">[source]</a></h3>\n",
+       "<h3 id=\"Config\" class=\"doc_header\"><code>class</code> <code>Config</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L250\" class=\"source_link\" style=\"float:right\">[source]</a></h3>\n",
        "\n",
        "> <code>Config</code>(**`cfg_path`**, **`cfg_name`**, **`create`**=*`None`*)\n",
        "\n",
@@ -209,25 +209,7 @@
        "{'jupytext': {'split_at_heading': True},\n",
        " 'kernelspec': {'display_name': 'Python 3',\n",
        "  'language': 'python',\n",
-       "  'name': 'python3'},\n",
-       " 'language_info': {'codemirror_mode': {'name': 'ipython', 'version': 3},\n",
-       "  'file_extension': '.py',\n",
-       "  'mimetype': 'text/x-python',\n",
-       "  'name': 'python',\n",
-       "  'nbconvert_exporter': 'python',\n",
-       "  'pygments_lexer': 'ipython3',\n",
-       "  'version': '3.8.10'},\n",
-       " 'toc': {'base_numbering': 1,\n",
-       "  'nav_menu': {},\n",
-       "  'number_sections': False,\n",
-       "  'sideBar': True,\n",
-       "  'skip_h1_title': True,\n",
-       "  'title_cell': 'Table of Contents',\n",
-       "  'title_sidebar': 'Contents',\n",
-       "  'toc_cell': False,\n",
-       "  'toc_position': {},\n",
-       "  'toc_section_display': True,\n",
-       "  'toc_window_display': False}}"
+       "  'name': 'python3'}}"
       ]
      },
      "execution_count": null,
@@ -275,7 +257,7 @@
      "data": {
       "text/plain": [
        "{'cell_type': 'code',\n",
-       " 'execution_count': 1,\n",
+       " 'execution_count': None,\n",
        " 'metadata': {'hide_input': False},\n",
        " 'outputs': [],\n",
        " 'source': '#hide\\n#default_exp export\\n#default_cls_lvl 3\\nfrom nbdev.showdoc import show_doc'}"
@@ -1257,7 +1239,7 @@
     "    \"Create a skeleton for <code>_nbdev</code>\"\n",
     "    fname = get_config().path(\"lib_path\")/'_nbdev.py'\n",
     "    fname.parent.mkdir(parents=True, exist_ok=True)\n",
-    "    sep = '\\n'* (int(get_config().get('cell_spacing', '1'))+1)\n",
+    "    sep = '\\n' * (get_config().d.getint('cell_spacing', 1) + 1)\n",
     "    if fname.is_file():\n",
     "        with open(fname, 'r') as f: search = _re_index_custom.search(f.read())\n",
     "    else: search = None\n",
@@ -1429,7 +1411,7 @@
     "#export\n",
     "def create_mod_file(fname, nb_path, bare=False):\n",
     "    \"Create a module file for `fname`.\"\n",
-    "    bare = str(get_config().get('bare', bare)) == 'True'\n",
+    "    bare = get_config().d.getboolean('bare', bare)\n",
     "    fname.parent.mkdir(parents=True, exist_ok=True)\n",
     "    file_path = os.path.relpath(nb_path, get_config().config_file.parent).replace('\\\\', '/')\n",
     "    with open(fname, 'w') as f:\n",
@@ -1501,9 +1483,9 @@
     "#export\n",
     "def _notebook2script(fname, modules, silent=False, to_dict=None, bare=False):\n",
     "    \"Finds cells starting with `#export` and puts them into a module created by `create_mod_files`\"\n",
-    "    bare = str(get_config().get('bare', bare)) == 'True'\n",
+    "    bare = get_config().d.getboolean('bare', bare)\n",
     "    if os.environ.get('IN_TEST',0): return  # don't export if running tests\n",
-    "    sep = '\\n'* (int(get_config().get('cell_spacing', '1'))+1)\n",
+    "    sep = '\\n' * (get_config().d.getint('cell_spacing', 1) + 1)\n",
     "    fname = Path(fname)\n",
     "    nb = read_nb(fname)\n",
     "    default = find_default_export(nb['cells'])\n",
@@ -1850,7 +1832,7 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -1375,7 +1375,8 @@
     "    if doc_string and inspect.getdoc(elt):\n",
     "        s = inspect.getdoc(elt)\n",
     "        # show_doc is used by doc so should not rely on Config\n",
-    "        try: monospace = (get_config().get('monospace_docstrings') == 'True')\n",
+    "        # We use except because `get_config` raises Exception if not found\n",
+    "        try: monospace = get_config().d.getboolean('monospace_docstrings', False)\n",
     "        except: monospace = False\n",
     "        # doc links don't work inside markdown pre/code blocks\n",
     "        s = f'```\\n{s}\\n```' if monospace else add_doc_links(s, elt)\n",
@@ -1729,6 +1730,54 @@
     "    else:\n",
     "        try: page.page({'text/html': output + _TABLE_CSS})\n",
     "        except: display(Markdown(md))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h4 id=\"doc\" class=\"doc_header\"><code>doc</code><a href=\"__main__.py#L2\" class=\"source_link\" style=\"float:right\">[source]</a></h4><blockquote><p><code>doc</code>(<strong><code>elt</code></strong>:<code>int</code>, <strong><code>show_all_docments</code></strong>:<code>bool</code>=<em><code>True</code></em>)</p>\n",
+       "</blockquote>\n",
+       "<p>Show <a href=\"/showdoc.html#show_doc\"><code>show_doc</code></a> info in preview window when used in a notebook</p>\n",
+       "<table>\n",
+       "<thead><tr>\n",
+       "<th></th>\n",
+       "<th>Type</th>\n",
+       "<th>Default</th>\n",
+       "</tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "<tr>\n",
+       "<td><strong><code>elt</code></strong></td>\n",
+       "<td><code>int</code></td>\n",
+       "<td></td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "<td><strong><code>show_all_docments</code></strong></td>\n",
+       "<td><code>bool</code></td>\n",
+       "<td><code>True</code></td>\n",
+       "</tr>\n",
+       "</tbody>\n",
+       "</table>\n",
+       "<style>\n",
+       "    table { border-collapse: collapse; border:thin solid #dddddd; margin: 25px 0px; ; }\n",
+       "    table tr:first-child { background-color: #FFF}\n",
+       "    table thead th { background-color: #eee; color: #000; text-align: center;}\n",
+       "    tr, th, td { border: 1px solid #ccc; border-width: 1px 0 0 1px; border-collapse: collapse;\n",
+       "    padding: 5px; }\n",
+       "    tr:nth-child(even) {background: #eee;}</style>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "doc(doc)"
    ]
   },
   {

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -943,8 +943,7 @@
    "source": [
     "#export\n",
     "def _show_doc_cell(name, cls_lvl=None):\n",
-    "    try: show_all = (get_config().get('show_all_docments') == 'True')\n",
-    "    except: show_all = False\n",
+    "    show_all = get_config().d.getboolean('show_all_docments', False)\n",
     "    return nb_code_cell(f\"show_doc({name}{'' if cls_lvl is None else f', default_cls_level={cls_lvl}'}, show_all_docments={show_all})\")\n",
     "\n",
     "def add_show_docs(cells, cls_lvl=None):\n",


### PR DESCRIPTION
Refactored most cases where only `try: catch:` exists.

There were some pre the last PR that I couldn't quite figure out, such as failing to render `page.page`. For that, might want to mimic how the function itself raises errors I imagine? (Source [here](https://github.com/ipython/ipython/blob/0f4a73c91db71cde174275337fc5e226acc9dd7d/IPython/core/page.py#L177))