### PR TITLE
better logging for duplicate titles

### DIFF
--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -699,7 +699,11 @@ def _create_default_sidebar():
     files = nbglob()
     fnames = [_nb2htmlfname(f) for f in sorted(files)]
     titles = [_get_title(f) for f in fnames if f.stem!='index']
-    if len(titles) > len(set(titles)): print(f"Warning: Some of your Notebooks use the same title ({titles}).")
+    d = {}
+    for f,t in zip(fnames, titles):
+        d[t] = d.get(t, []) + [str(f)]
+    for k,v in d.items():
+        if len(v) > 1: print(f'WARNING: The title: "{k}" appears in {len(v)} pages:\n\t\t{v}')
     dic.update({_get_title(f):f.name if get_config().host=='github' else f.with_suffix('').name for f in fnames if f.stem!='index'})
     return dic
 

--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -699,8 +699,8 @@ def _create_default_sidebar():
     files = nbglob()
     fnames = [_nb2htmlfname(f) for f in sorted(files)]
     names = [f for f in fnames if f.stem!='index']
-    dupes = [(t,str(f)) for t,f in groupby(names, _get_title).items() if len(f) > 1]
-    for t,f in dupes: print(f'WARNING: The title: "{t}" appears in {len(f)} pages:\n\t\t{f}')
+    for t,f in groupby(names, _get_title).items():
+        if len(f) > 1: print(f'WARNING: The title: "{t}" appears in {len(f)} pages:\n\t\t{L(f).map(str)}')
     dic.update({_get_title(f):f.name if get_config().host=='github' else f.with_suffix('').name for f in fnames if f.stem!='index'})
     return dic
 

--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -698,8 +698,8 @@ def _create_default_sidebar():
     dic = {"Overview": "/"}
     files = nbglob()
     fnames = [_nb2htmlfname(f) for f in sorted(files)]
-    titles = [_get_title(f) for f in fnames if f.stem!='index']
-    dupes = [(t,str(f)) for t,f in groupby(zip(titles, fnames), 0, 1).items() if len(f) > 1]
+    names = [f for f in fnames if f.stem!='index']
+    dupes = [(t,str(f)) for t,f in groupby(names, _get_title).items() if len(f) > 1]
     for t,f in dupes: print(f'WARNING: The title: "{t}" appears in {len(f)} pages:\n\t\t{f}')
     dic.update({_get_title(f):f.name if get_config().host=='github' else f.with_suffix('').name for f in fnames if f.stem!='index'})
     return dic

--- a/nbdev/export2html.py
+++ b/nbdev/export2html.py
@@ -699,11 +699,8 @@ def _create_default_sidebar():
     files = nbglob()
     fnames = [_nb2htmlfname(f) for f in sorted(files)]
     titles = [_get_title(f) for f in fnames if f.stem!='index']
-    d = {}
-    for f,t in zip(fnames, titles):
-        d[t] = d.get(t, []) + [str(f)]
-    for k,v in d.items():
-        if len(v) > 1: print(f'WARNING: The title: "{k}" appears in {len(v)} pages:\n\t\t{v}')
+    dupes = [(t,str(f)) for t,f in groupby(zip(titles, fnames), 0, 1).items() if len(f) > 1]
+    for t,f in dupes: print(f'WARNING: The title: "{t}" appears in {len(f)} pages:\n\t\t{f}')
     dic.update({_get_title(f):f.name if get_config().host=='github' else f.with_suffix('').name for f in fnames if f.stem!='index'})
     return dic
 

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -2125,8 +2125,8 @@
     "    dic = {\"Overview\": \"/\"}\n",
     "    files = nbglob()\n",
     "    fnames = [_nb2htmlfname(f) for f in sorted(files)]\n",
-    "    titles = [_get_title(f) for f in fnames if f.stem!='index']\n",
-    "    dupes = [(t,str(f)) for t,f in groupby(zip(titles, fnames), 0, 1).items() if len(f) > 1]\n",
+    "    names = [f for f in fnames if f.stem!='index']\n",
+    "    dupes = [(t,str(f)) for t,f in groupby(names, _get_title).items() if len(f) > 1]\n",
     "    for t,f in dupes: print(f'WARNING: The title: \"{t}\" appears in {len(f)} pages:\\n\\t\\t{f}')\n",
     "    dic.update({_get_title(f):f.name if get_config().host=='github' else f.with_suffix('').name for f in fnames if f.stem!='index'})\n",
     "    return dic"

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -2125,9 +2125,9 @@
     "    dic = {\"Overview\": \"/\"}\n",
     "    files = nbglob()\n",
     "    fnames = [_nb2htmlfname(f) for f in sorted(files)]\n",
-    "    names = L([f for f in fnames if f.stem!='index'])\n",
+    "    names = [f for f in fnames if f.stem!='index']\n",
     "    for t,f in groupby(names, _get_title).items():\n",
-    "        if len(f) > 1: print(f'WARNING: The title: \"{t}\" appears in {len(f)} pages:\\n\\t\\t{f.map(str)}')\n",
+    "        if len(f) > 1: print(f'WARNING: The title: \"{t}\" appears in {len(f)} pages:\\n\\t\\t{L(f).map(str)}')\n",
     "    dic.update({_get_title(f):f.name if get_config().host=='github' else f.with_suffix('').name for f in fnames if f.stem!='index'})\n",
     "    return dic"
    ]

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -2126,7 +2126,11 @@
     "    files = nbglob()\n",
     "    fnames = [_nb2htmlfname(f) for f in sorted(files)]\n",
     "    titles = [_get_title(f) for f in fnames if f.stem!='index']\n",
-    "    if len(titles) > len(set(titles)): print(f\"Warning: Some of your Notebooks use the same title ({titles}).\")\n",
+    "    d = {}\n",
+    "    for f,t in zip(fnames, titles):\n",
+    "        d[t] = d.get(t, []) + [str(f)]\n",
+    "    for k,v in d.items():\n",
+    "        if len(v) > 1: print(f'WARNING: The title: \"{k}\" appears in {len(v)} pages:\\n\\t\\t{v}')\n",
     "    dic.update({_get_title(f):f.name if get_config().host=='github' else f.with_suffix('').name for f in fnames if f.stem!='index'})\n",
     "    return dic"
    ]

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -2126,11 +2126,8 @@
     "    files = nbglob()\n",
     "    fnames = [_nb2htmlfname(f) for f in sorted(files)]\n",
     "    titles = [_get_title(f) for f in fnames if f.stem!='index']\n",
-    "    d = {}\n",
-    "    for f,t in zip(fnames, titles):\n",
-    "        d[t] = d.get(t, []) + [str(f)]\n",
-    "    for k,v in d.items():\n",
-    "        if len(v) > 1: print(f'WARNING: The title: \"{k}\" appears in {len(v)} pages:\\n\\t\\t{v}')\n",
+    "    dupes = [(t,str(f)) for t,f in groupby(zip(titles, fnames), 0, 1).items() if len(f) > 1]\n",
+    "    for t,f in dupes: print(f'WARNING: The title: \"{t}\" appears in {len(f)} pages:\\n\\t\\t{f}')\n",
     "    dic.update({_get_title(f):f.name if get_config().host=='github' else f.with_suffix('').name for f in fnames if f.stem!='index'})\n",
     "    return dic"
    ]

--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -2125,9 +2125,9 @@
     "    dic = {\"Overview\": \"/\"}\n",
     "    files = nbglob()\n",
     "    fnames = [_nb2htmlfname(f) for f in sorted(files)]\n",
-    "    names = [f for f in fnames if f.stem!='index']\n",
-    "    dupes = [(t,str(f)) for t,f in groupby(names, _get_title).items() if len(f) > 1]\n",
-    "    for t,f in dupes: print(f'WARNING: The title: \"{t}\" appears in {len(f)} pages:\\n\\t\\t{f}')\n",
+    "    names = L([f for f in fnames if f.stem!='index'])\n",
+    "    for t,f in groupby(names, _get_title).items():\n",
+    "        if len(f) > 1: print(f'WARNING: The title: \"{t}\" appears in {len(f)} pages:\\n\\t\\t{f.map(str)}')\n",
     "    dic.update({_get_title(f):f.name if get_config().host=='github' else f.with_suffix('').name for f in fnames if f.stem!='index'})\n",
     "    return dic"
    ]


### PR DESCRIPTION
These changes will change the logging message to look like this:

```
WARNING: The title: "Title" appears in 2 pages:
		['/Users/hamel/github/fastai/docs/data.load.html', '/Users/hamel/github/fastai/docs/camvid.html']
```

@jph00 ready for review