### PR TITLE
Use the kernel defined in the kernelspec

### DIFF
--- a/nbs/03_export2html.ipynb
+++ b/nbs/03_export2html.ipynb
@@ -1403,7 +1403,7 @@
     "    mods = ([] if mod is None else [mod]) + _gather_export_mods(nb['cells'])\n",
     "    nb['cells'].insert(0, _import_show_doc_cell(mods))\n",
     "    ep_cls = ExecuteShowDocPreprocessor if show_doc_only else ExecutePreprocessor\n",
-    "    ep = ep_cls(timeout=600, kernel_name='python3')\n",
+    "    ep = ep_cls(timeout=600)\n",
     "    metadata = metadata or {}\n",
     "    pnb = nbformat.from_dict(nb)\n",
     "    ep.preprocess(pnb, metadata)\n",


### PR DESCRIPTION
The notebook metadata has a kernelspec section which defines the kernel
to use with the notebook:
```
  ...
  "metadata": {
    "jupytext": {
     "split_at_heading": true
    },
    "kernelspec": {
     "display_name": "Python 3 (ipykernel)",
     "language": "python",
     "name": "python3"
    },
    ...
```

Instead of hard coding the kernel name to "python3" we use the default
behavior of using the kernel that the notebook was run with.

See: https://forums.fast.ai/t/modulenotfounderror-in-fresh-conda-environment/93666