### PR TITLE
Better checks for cls and self

### DIFF
--- a/nbdev/showdoc.py
+++ b/nbdev/showdoc.py
@@ -290,6 +290,17 @@ def _generate_return_string(return_dict:dict, has_docment=False):
     return return_string if not has_docment else f"{return_string}{return_dict['docment']}|"
 
 # Cell
+def _is_static(func):
+    "Checks whether `func` is a static method in a class"
+    name = qual_name(func)
+    if len(name.split(".")) == 2:
+        cls, nm = name.split('.')
+        cls = getattr(sys.modules[func.__module__], cls)
+        method_type = inspect.getattr_static(cls, nm)
+        return isinstance(method_type, staticmethod)
+    return False
+
+# Cell
 def _format_args(elt, ment_dict:dict = None, kwargs = [], monospace=False, is_class=False):
     "Generates a formatted argument string, potentially from an existing `ment_dict`"
     if ment_dict is None:

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -1170,6 +1170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#export\n",
     "def _is_static(func):\n",
     "    \"Checks whether `func` is a static method in a class\"\n",
     "    name = qual_name(func)\n",

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -1170,15 +1170,68 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "def _is_static(func):\n",
+    "    \"Checks whether `func` is a static method in a class\"\n",
+    "    name = qual_name(func)\n",
+    "    if len(name.split(\".\")) == 2:\n",
+    "        cls, nm = name.split('.')\n",
+    "        cls = getattr(sys.modules[func.__module__], cls)\n",
+    "        method_type = inspect.getattr_static(cls, nm)\n",
+    "        return isinstance(method_type, staticmethod)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#hide\n",
+    "class _A:\n",
+    "    def __init__(self, \n",
+    "            a, # First number\n",
+    "            b # Second number\n",
+    "        ):\n",
+    "        self.a = a\n",
+    "        self.b = b\n",
+    "\n",
+    "    @classmethod\n",
+    "    def from_self(cls, *args):\n",
+    "        return cls(*args)\n",
+    "    \n",
+    "    @staticmethod\n",
+    "    def _add(\n",
+    "        a, # First val\n",
+    "        b # Second val\n",
+    "    ): return a+b\n",
+    "\n",
+    "    def add(self # Should be ignored\n",
+    "        ): return self._add(self.a, self.b)\n",
+    "\n",
+    "test_eq(_is_static(_A), False)\n",
+    "test_eq(_is_static(_A.__init__), False)\n",
+    "test_eq(_is_static(_A.add), False)\n",
+    "test_eq(_is_static(_A._add), True)\n",
+    "test_eq(_is_static(_A.from_self), False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "#export\n",
-    "def _format_args(elt, ment_dict:dict = None, kwargs = [], monospace=False):\n",
+    "def _format_args(elt, ment_dict:dict = None, kwargs = [], monospace=False, is_class=False):\n",
     "    \"Generates a formatted argument string, potentially from an existing `ment_dict`\"\n",
     "    if ment_dict is None:\n",
     "        ment_dict = docments(elt, full=True)\n",
     "    arg_string = \"\"\n",
     "    return_string = \"\"\n",
-    "    ment_dict.pop(\"self\", {})\n",
-    "    ment_dict.pop(\"cls\", {})\n",
+    "    if not _is_static(elt) and is_class:\n",
+    "        ment_dict.pop(\"self\", {})\n",
+    "        ment_dict.pop(\"cls\", {})\n",
     "    ret = ment_dict.pop(\"return\", None)\n",
     "    has_docment = _has_docment(elt)\n",
     "    if len(ment_dict.keys()) > 0:\n",
@@ -1251,6 +1304,18 @@
     "    \"Adds two numbers together\"\n",
     "    return a+b\n",
     "test_eq(_format_args(addition), '||Type|Default|Details|\\n|---|---|---|---|\\n|**`a`**|`int`||The first number to add<br />The starting value|\\n|**`b`**|`float`|`2`|The second number to add<br />The addend|\\n|**Returns**|`(int, float)`||The sum of `a` and `b`<br />Our return|')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#hide\n",
+    "test_eq(_format_args(_A._add, is_class=True), '||Type|Default|Details|\\n|---|---|---|---|\\n|**`a`**|||First val|\\n|**`b`**|||Second val|\\n')\n",
+    "test_eq(_format_args(_A.__init__, is_class=True), '||Type|Default|Details|\\n|---|---|---|---|\\n|**`a`**|||First number|\\n|**`b`**|||Second number|\\n')\n",
+    "test_eq(_format_args(_A.add, is_class=True), '')"
    ]
   },
   {
@@ -1399,12 +1464,10 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def _get_docments(elt, with_return=False, ment_dict=None, kwargs=[], monospace=False):\n",
+    "def _get_docments(elt, with_return=False, ment_dict=None, kwargs=[], monospace=False, is_class=False):\n",
     "    \"Grabs docments for `elt` and formats with a potential `ment_dict` and valid kwarg names\"\n",
-    "    s = f\"\\n\\n{_format_args(elt, ment_dict=ment_dict, kwargs=kwargs, monospace=monospace)}\"\n",
-    "    if not with_return: \n",
-    "        \n",
-    "        s = s.split(\"|**Returns**|\")[0]\n",
+    "    s = f\"\\n\\n{_format_args(elt, ment_dict=ment_dict, kwargs=kwargs, monospace=monospace, is_class=is_class)}\"\n",
+    "    if not with_return: s = s.split(\"|**Returns**|\")[0]\n",
     "    return s"
    ]
   },
@@ -1432,6 +1495,7 @@
     "    \"Show documentation for element `elt` with potential input documentation. Supported types: class, function, and enum.\"\n",
     "    elt = getattr(elt, '__func__', elt)\n",
     "    qname = name or qual_name(elt)\n",
+    "    is_class = '.' in qname or inspect.isclass\n",
     "    if inspect.isclass(elt):\n",
     "        if is_enum(elt): name,args = _format_enum_doc(elt, qname)\n",
     "        else:            name,args = _format_cls_doc (elt, qname)\n",
@@ -1443,7 +1507,10 @@
     "    doc =  f'<h{title_level} id=\"{qname}\" class=\"doc_header\">{name}{source_link}</h{title_level}>'\n",
     "    doc += f'\\n\\n> {args}\\n\\n' if len(args) > 0 else '\\n\\n'\n",
     "    s = ''\n",
-    "    monospace = get_config().d.getboolean('monospace_docstrings', False)\n",
+    "    try:\n",
+    "        monospace = get_config().d.getboolean('monospace_docstrings', False)\n",
+    "    except FileNotFoundError:\n",
+    "        monospace = False\n",
     "    if doc_string and inspect.getdoc(elt):\n",
     "        s = inspect.getdoc(elt)\n",
     "        # doc links don't work inside markdown pre/code blocks\n",
@@ -1456,9 +1523,9 @@
     "            if show_all_docments or _has_docment(elt):\n",
     "                if hasattr(elt, \"__delwrap__\"):\n",
     "                    arg_dict, kwargs = _handle_delegates(elt)\n",
-    "                    doc += _get_docments(elt, ment_dict=arg_dict, with_return=True, kwargs=kwargs, monospace=monospace)\n",
+    "                    doc += _get_docments(elt, ment_dict=arg_dict, with_return=True, kwargs=kwargs, monospace=monospace, is_class=is_class)\n",
     "                else:\n",
-    "                    doc += _get_docments(elt, monospace=monospace)\n",
+    "                    doc += _get_docments(elt, monospace=monospace, is_class=is_class)\n",
     "            elif verbose:\n",
     "                print(f'Warning: `docments` annotations will not work for built-in modules, classes, functions, and `enums` and are unavailable for {qual_name(elt)}. They will not be shown')\n",
     "    if disp: display(Markdown(doc))\n",
@@ -1545,7 +1612,9 @@
     "_str = '<h4 id=\"_b\" class=\"doc_header\"><code>_b</code><a href=\"__main__.py#L8\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\\n\\n> <code>_b</code>(**`b`**:`str`, **`a`**:`int`=*`2`*)\\n\\n\\n\\n||Type|Default|Details|\\n|---|---|---|---|\\n|**`b`**|`str`||Second|\\n|||**Valid Keyword Arguments**||\\n|**`a`**|`int`|`2`|First passed to `_a`|\\n'\n",
     "test_eq(show_doc(_b, disp=False), _str)\n",
     "_str = '<h4 id=\"_d\" class=\"doc_header\"><code>_d</code><a href=\"__main__.py#L20\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\\n\\n> <code>_d</code>(**`c`**:`int`, **`b`**:`str`, **`a`**:`int`=*`2`*)\\n\\n\\n\\n||Type|Default|Details|\\n|---|---|---|---|\\n|**`c`**|`int`||First|\\n|||**Valid Keyword Arguments**||\\n|**`b`**|`str`||Second passed to `_c`|\\n|**`a`**|`int`|`2`|Blah passed to `_c`|\\n'\n",
-    "test_eq(show_doc(_d, disp=False), _str)"
+    "test_eq(show_doc(_d, disp=False), _str)\n",
+    "_str = '<h4 id=\"_A._add\" class=\"doc_header\"><code>_A._add</code><a href=\"__main__.py#L14\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\\n\\n> <code>_A._add</code>(**`a`**, **`b`**)\\n\\n\\n\\n||Type|Default|Details|\\n|---|---|---|---|\\n|**`a`**|||First val|\\n|**`b`**|||Second val|\\n'\n",
+    "test_eq(show_doc(_A._add, disp=False), _str)"
    ]
   },
   {


### PR DESCRIPTION
Fixes a bug where `cls` and `self` were always popped if present, a lazy approach to testing if it's a method in a class  or not. This PR addresses this and provides a fix. Also fixes a slight error with `get_config` right now (see note in Discord on this). Should be merged after https://github.com/fastai/fastcore/pull/394