### PR TITLE
Fix decimal bug

### DIFF
--- a/nbdev/showdoc.py
+++ b/nbdev/showdoc.py
@@ -171,8 +171,11 @@ def _format_annos(anno, highlight=False):
     new_anno = "(" if len(annos) > 1 else ""
     def _inner(o): return getattr(o, '__qualname__', str(o)) if '<' in str(o) else str(o)
     for i, anno in enumerate(annos):
-        new_anno += _inner(anno) if not highlight else f'{doc_link(_inner(anno))}'
-        if "." in new_anno: new_anno = new_anno.split('.')[-1]
+        if str(anno).replace('.', '').isnumeric():
+            new_anno += str(anno)
+        else:
+            new_anno += _inner(anno) if not highlight else f'{doc_link(_inner(anno))}'
+            if "." in new_anno: new_anno = new_anno.split('.')[-1]
         if len(annos) > 1 and i < len(annos) - 1:
             new_anno += ', '
     return f'{new_anno})' if len(annos) > 1 else new_anno

--- a/nbdev/showdoc.py
+++ b/nbdev/showdoc.py
@@ -171,7 +171,7 @@ def _format_annos(anno, highlight=False):
     new_anno = "(" if len(annos) > 1 else ""
     def _inner(o): return getattr(o, '__qualname__', str(o)) if '<' in str(o) else str(o)
     for i, anno in enumerate(annos):
-        if str(anno).replace('.', '').isnumeric():
+        if str(anno).replace('.', '').isnumeric() or isinstance(anno, str):
             new_anno += str(anno)
         else:
             new_anno += _inner(anno) if not highlight else f'{doc_link(_inner(anno))}'

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -599,7 +599,7 @@
     "    new_anno = \"(\" if len(annos) > 1 else \"\"\n",
     "    def _inner(o): return getattr(o, '__qualname__', str(o)) if '<' in str(o) else str(o)\n",
     "    for i, anno in enumerate(annos):\n",
-    "        if str(anno).replace('.', '').isnumeric(): \n",
+    "        if str(anno).replace('.', '').isnumeric() or isinstance(anno, str): \n",
     "            new_anno += str(anno)\n",
     "        else:\n",
     "            new_anno += _inner(anno) if not highlight else f'{doc_link(_inner(anno))}'\n",
@@ -626,7 +626,8 @@
     "test_eq(_format_annos(L, highlight=True), '`L`')\n",
     "test_eq(_format_annos((L,list), highlight=True), '(`L`, `list`)')\n",
     "test_eq(_format_annos(None), \"None\")\n",
-    "test_eq(_format_annos(2.2), \"2.2\")"
+    "test_eq(_format_annos(2.2), \"2.2\")\n",
+    "test_eq(_format_annos(\"Test me.\"), \"Test me.\")"
    ]
   },
   {

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -599,8 +599,11 @@
     "    new_anno = \"(\" if len(annos) > 1 else \"\"\n",
     "    def _inner(o): return getattr(o, '__qualname__', str(o)) if '<' in str(o) else str(o)\n",
     "    for i, anno in enumerate(annos):\n",
-    "        new_anno += _inner(anno) if not highlight else f'{doc_link(_inner(anno))}'\n",
-    "        if \".\" in new_anno: new_anno = new_anno.split('.')[-1]\n",
+    "        if str(anno).replace('.', '').isnumeric(): \n",
+    "            new_anno += str(anno)\n",
+    "        else:\n",
+    "            new_anno += _inner(anno) if not highlight else f'{doc_link(_inner(anno))}'\n",
+    "            if \".\" in new_anno: new_anno = new_anno.split('.')[-1]\n",
     "        if len(annos) > 1 and i < len(annos) - 1:\n",
     "            new_anno += ', '\n",
     "    return f'{new_anno})' if len(annos) > 1 else new_anno"
@@ -622,7 +625,8 @@
     "test_eq(_format_annos(L), 'L')\n",
     "test_eq(_format_annos(L, highlight=True), '`L`')\n",
     "test_eq(_format_annos((L,list), highlight=True), '(`L`, `list`)')\n",
-    "test_eq(_format_annos(None), \"None\")"
+    "test_eq(_format_annos(None), \"None\")\n",
+    "test_eq(_format_annos(2.2), \"2.2\")"
    ]
   },
   {
@@ -943,7 +947,12 @@
     "        \"docment\": \"Blah blah\",\n",
     "        \"anno\": int,\n",
     "        \"default\": None\n",
-    "    } \n",
+    "    } ,\n",
+    "    \"with-float\": {\n",
+    "        \"docment\": \"A float default\",\n",
+    "        \"anno\": float,\n",
+    "        \"default\": .89\n",
+    "    }\n",
     "}"
    ]
   },
@@ -1033,6 +1042,17 @@
     "#hide\n",
     "_str = '||Type|Default|Details|\\n|---|---|---|---|\\n|**`multi-none`**||`None`|Blah|\\n'\n",
     "test_eq(_generate_arg_string({\"multi-none\":args[\"multi-none\"]}, has_docment=True), _str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#hide\n",
+    "_str = '||Type|Default|Details|\\n|---|---|---|---|\\n|**`with-float`**|`float`|`0.89`|A float default|\\n'\n",
+    "test_eq(_generate_arg_string({\"with-float\":args[\"with-float\"]}, has_docment=True), _str)"
    ]
   },
   {


### PR DESCRIPTION
Fixes a bug pointed out in discord where if it's a numerical type, we ignore the decimals and just return the string representation of it in `_format_annos`

This can also be a special case as numbers would be the only time outside of a import we'd expect a decimal to show as the original decimal, as well as if there's a string as a default it should just show the string!

cc  @jph00 