### PR TITLE
Keep module in name when getting the "qualname"

### DIFF
--- a/nbdev/showdoc.py
+++ b/nbdev/showdoc.py
@@ -172,7 +172,7 @@ def _format_annos(anno, highlight=False):
     def _inner(o): return getattr(o, '__qualname__', str(o)) if '<' in str(o) else str(o)
     for i, anno in enumerate(annos):
         new_anno += _inner(anno) if not highlight else f'{doc_link(_inner(anno))}'
-        if "." in new_anno: new_anno = new_anno.split('.')[-1]
+        # if "." in new_anno: new_anno = new_anno.split('.')[-1]
         if len(annos) > 1 and i < len(annos) - 1:
             new_anno += ', '
     return f'{new_anno})' if len(annos) > 1 else new_anno

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -600,7 +600,7 @@
     "    def _inner(o): return getattr(o, '__qualname__', str(o)) if '<' in str(o) else str(o)\n",
     "    for i, anno in enumerate(annos):\n",
     "        new_anno += _inner(anno) if not highlight else f'{doc_link(_inner(anno))}'\n",
-    "        if \".\" in new_anno: new_anno = new_anno.split('.')[-1]\n",
+    "        # if \".\" in new_anno: new_anno = new_anno.split('.')[-1]\n",
     "        if len(annos) > 1 and i < len(annos) - 1:\n",
     "            new_anno += ', '\n",
     "    return f'{new_anno})' if len(annos) > 1 else new_anno"
@@ -613,16 +613,17 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "from typing import Union, Tuple\n",
-    "test_eq(_format_annos(Union[int,float]), 'Union[int, float]')\n",
-    "test_eq(_format_annos(Tuple[int,float]), 'Tuple[int, float]')\n",
+    "from typing import Union, Tuple, List\n",
+    "test_eq(_format_annos(Union[int,float]), 'typing.Union[int, float]')\n",
+    "test_eq(_format_annos(Tuple[int,float]), 'typing.Tuple[int, float]')\n",
     "test_ne(_format_annos(Tuple[int,float]), 'typing.Tuple[int,float]')\n",
     "test_eq(_format_annos((int,float)), '(int, float)')\n",
     "test_eq(_format_annos(int), 'int')\n",
     "test_eq(_format_annos(L), 'L')\n",
     "test_eq(_format_annos(L, highlight=True), '`L`')\n",
     "test_eq(_format_annos((L,list), highlight=True), '(`L`, `list`)')\n",
-    "test_eq(_format_annos(None), \"None\")"
+    "test_eq(_format_annos(None), \"None\")\n",
+    "test_eq(_format_annos(Union[List[str],str]), 'typing.Union[typing.List[str], str]')"
    ]
   },
   {
@@ -998,7 +999,7 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "_str = '||Type|Default|Details|\\n|---|---|---|---|\\n|**`multitype-basetypes`**|`Union[int, float]`||Testing typing!|\\n'\n",
+    "_str = '||Type|Default|Details|\\n|---|---|---|---|\\n|**`multitype-basetypes`**|`typing.Union[int, float]`||Testing typing!|\\n'\n",
     "test_eq(_generate_arg_string({\"multitype-basetypes\":args[\"multitype-basetypes\"]}, has_docment=True), _str)"
    ]
   },
@@ -1139,7 +1140,7 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "_str = \"|**Returns**|`Union[int, float]`||Sum of parts|\"\n",
+    "_str = \"|**Returns**|`typing.Union[int, float]`||Sum of parts|\"\n",
     "test_eq(_generate_return_string(_return_dict[\"typing\"], has_docment=True), _str)"
    ]
   },

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -624,8 +624,6 @@
     "test_eq(_format_annos((L,list), highlight=True), '(`L`, `list`)')\n",
     "test_eq(_format_annos(None), \"None\")\n",
     "test_eq(_format_annos(Union[List[str],str]), 'typing.Union[typing.List[str], str]')"
-    "test_eq(_format_annos(2.2), \"2.2\")\n",
-    "test_eq(_format_annos(\"Test me.\"), \"Test me.\")"
    ]
   },
   {
@@ -946,12 +944,7 @@
     "        \"docment\": \"Blah blah\",\n",
     "        \"anno\": int,\n",
     "        \"default\": None\n",
-    "    } ,\n",
-    "    \"with-float\": {\n",
-    "        \"docment\": \"A float default\",\n",
-    "        \"anno\": float,\n",
-    "        \"default\": .89\n",
-    "    }\n",
+    "    } \n",
     "}"
    ]
   },
@@ -1041,17 +1034,6 @@
     "#hide\n",
     "_str = '||Type|Default|Details|\\n|---|---|---|---|\\n|**`multi-none`**||`None`|Blah|\\n'\n",
     "test_eq(_generate_arg_string({\"multi-none\":args[\"multi-none\"]}, has_docment=True), _str)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#hide\n",
-    "_str = '||Type|Default|Details|\\n|---|---|---|---|\\n|**`with-float`**|`float`|`0.89`|A float default|\\n'\n",
-    "test_eq(_generate_arg_string({\"with-float\":args[\"with-float\"]}, has_docment=True), _str)"
    ]
   },
   {


### PR DESCRIPTION
Closes https://github.com/fastai/nbdev/issues/603

Previous behavior was to disregard the library if we had a typing such as `typing.Union[int, float]`. But due to the fact these can be nested (such as `Union[List[str],str]` would be, `typing.Union[typing.List[str], str]`), it's better to just keep the library / module inside it.

cc @jph00 