### PR TITLE
Change doc() default for docments

### DIFF
--- a/nbdev/showdoc.py
+++ b/nbdev/showdoc.py
@@ -438,7 +438,7 @@ _TABLE_CSS = """<style>
     tr:nth-child(even) {background: #eee;}</style>"""
 
 # Cell
-def doc(elt:int, show_all_docments:bool=True):
+def doc(elt, show_all_docments:bool=False):
     "Show `show_doc` info in preview window when used in a notebook"
     md = show_doc(elt, disp=False, show_all_docments=show_all_docments)
     doc_link = get_doc_link(elt)

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -1917,7 +1917,7 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def doc(elt:int, show_all_docments:bool=True):\n",
+    "def doc(elt, show_all_docments:bool=False):\n",
     "    \"Show `show_doc` info in preview window when used in a notebook\"\n",
     "    md = show_doc(elt, disp=False, show_all_docments=show_all_docments)\n",
     "    doc_link = get_doc_link(elt)\n",


### PR DESCRIPTION
# Change default for `doc` to not show docments always

## What does this add?

Slightly changes default behavior in `doc`

## Why is it needed?

Current default is to always show docments, even if no docments are present when doing `doc(elt)`, it should be `False` to mimic `show_doc` behavior and only show docments if they are available. Also removed :int typehint (unsure when this was added, dug through commits and still couldn't find where/when)

cc @jph00