### PR TITLE
Added webrick spec to Gemfile.

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -6,3 +6,5 @@ gem 'github-pages', group: :jekyll_plugins
 gem "jekyll", ">= 3.7"
 gem "kramdown", ">= 2.3.1"
 gem "jekyll-remote-theme"
+
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
Building docker-compose image on WSL2 throws exception
`
nbdev-jekyll-1    | /var/lib/gems/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve/servlet.rb:3:in require: cannot load such file -- webrick (LoadError)
`
Addition of
`
gem "webrick", "~> 1.7"
`
into `Gemfile` solves the problem.