### PR TITLE
Fix show_doc for dataclass

### DIFF
--- a/nbdev/showdoc.py
+++ b/nbdev/showdoc.py
@@ -15,6 +15,7 @@ from fastcore.xtras import get_source_link, _unwrapped_type_dispatch_func
 
 import string
 from tokenize import COMMENT
+from dataclasses import dataclass, is_dataclass
 
 try:
     from IPython.display import Markdown,display
@@ -399,10 +400,12 @@ def show_doc(elt, doc_string:bool=True, name=None, title_level=None, disp=True, 
         s = f'```\n{s}\n```' if monospace else add_doc_links(s, elt)
         doc += s
     if len(args) > 0:
-        if hasattr(elt, '__init__') and isclass(elt):
+        if hasattr(elt, '__init__') and isclass(elt) and not is_dataclass(elt):
+            # dataclass doesn't have accessible __init__
             elt = elt.__init__
         if is_source_available(elt):
-            if show_all_docments or _has_docment(elt):
+            if not is_dataclass(elt) and (show_all_docments or _has_docment(elt)):
+                # temporary fix for dataclass definition until `docments` is fixed
                 if hasattr(elt, "__delwrap__"):
                     arg_dict, kwargs = _handle_delegates(elt)
                     doc += _get_docments(elt, ment_dict=arg_dict, with_return=True, kwargs=kwargs, monospace=monospace, is_class=is_class)

--- a/nbdev/showdoc.py
+++ b/nbdev/showdoc.py
@@ -245,7 +245,7 @@ def _format_cls_doc(cls, full_name):
 # Cell
 def _has_docment(elt):
     comments = {o.start[0]:_clean_comment(o.string) for o in _tokens(elt) if o.type==COMMENT}
-    params = _param_locs(elt, returns=True)
+    params = _param_locs(elt, returns=True) or {}
     comments = [_get_comment(line,arg,comments,params) for line,arg in params.items()]
     return any(c is not None for c in comments)
 
@@ -404,8 +404,7 @@ def show_doc(elt, doc_string:bool=True, name=None, title_level=None, disp=True, 
             # dataclass doesn't have accessible __init__
             elt = elt.__init__
         if is_source_available(elt):
-            if not is_dataclass(elt) and (show_all_docments or _has_docment(elt)):
-                # temporary fix for dataclass definition until `docments` is fixed
+            if show_all_docments or _has_docment(elt):
                 if hasattr(elt, "__delwrap__"):
                     arg_dict, kwargs = _handle_delegates(elt)
                     doc += _get_docments(elt, ment_dict=arg_dict, with_return=True, kwargs=kwargs, monospace=monospace, is_class=is_class)

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -1708,8 +1708,8 @@
    "source": [
     "#hide\n",
     "tmp = Path('temp.py')\n",
-    "tmp.write_text(\"\"\"\n",
-    "from typing import Sequence\n",
+    "tmp.write_text(\n",
+    "\"\"\"from typing import Sequence\n",
     "from dataclasses import dataclass\n",
     "@dataclass\n",
     "class A:\n",
@@ -1723,8 +1723,12 @@
     "    )->str: # it's a return string\n",
     "        return d\n",
     "\"\"\")\n",
+    "from sys import version_info\n",
     "import temp\n",
-    "tst_str = '<h2 id=\"A\" class=\"doc_header\"><code>class</code> <code>A</code><a href=\"temp.py#L4\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\\n\\n> <code>A</code>(**`a`**:`int`=*`2`*, **`b`**:`Sequence`\\\\[`int`\\\\]=*`(1, 2, 3)`*)\\n\\nTest dataclass\\n\\n||Type|Default|Details|\\n|---|---|---|---|\\n|**`a`**|`int`|`2`|First argument|\\n|**`b`**|`typing.Sequence[int]`|`(1, 2, 3)`|Second argument|\\n'\n",
+    "\n",
+    "tst_str = '<h2 id=\"A\" class=\"doc_header\"><code>class</code> <code>A</code><a href=\"temp.py#L3\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\\n\\n> <code>A</code>(**`a`**:`int`=*`2`*, **`b`**:`Sequence`\\\\[`int`\\\\]=*`(1, 2, 3)`*)\\n\\nTest dataclass\\n\\n||Type|Default|Details|\\n|---|---|---|---|\\n|**`a`**|`int`|`2`|First argument|\\n|**`b`**|`typing.Sequence[int]`|`(1, 2, 3)`|Second argument|\\n'\n",
+    "if version_info.minor < 9: tst_str = tst_str.replace('temp.py#L3', 'temp.py#L4')\n",
+    "\n",
     "assert tst_str == show_doc(temp.A, disp=False)\n",
     "try:\n",
     "    tmp.unlink()\n",
@@ -2064,7 +2068,7 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3.9.12 ('base')",
+   "display_name": "Python 3.9.12",
    "language": "python",
    "name": "python3"
   }

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -31,6 +31,7 @@
     "\n",
     "import string\n",
     "from tokenize import COMMENT\n",
+    "from dataclasses import dataclass, is_dataclass\n",
     "\n",
     "try:\n",
     "    from IPython.display import Markdown,display\n",
@@ -1529,10 +1530,12 @@
     "        s = f'```\\n{s}\\n```' if monospace else add_doc_links(s, elt)\n",
     "        doc += s\n",
     "    if len(args) > 0:\n",
-    "        if hasattr(elt, '__init__') and isclass(elt):\n",
+    "        if hasattr(elt, '__init__') and isclass(elt) and not is_dataclass(elt):\n",
+    "            # dataclass doesn't have accessible __init__\n",
     "            elt = elt.__init__\n",
     "        if is_source_available(elt):\n",
-    "            if show_all_docments or _has_docment(elt):\n",
+    "            if not is_dataclass(elt) and (show_all_docments or _has_docment(elt)):\n",
+    "                # temporary fix for dataclass definition until `docments` is fixed\n",
     "                if hasattr(elt, \"__delwrap__\"):\n",
     "                    arg_dict, kwargs = _handle_delegates(elt)\n",
     "                    doc += _get_docments(elt, ment_dict=arg_dict, with_return=True, kwargs=kwargs, monospace=monospace, is_class=is_class)\n",
@@ -1570,7 +1573,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"notebook2script\" class=\"doc_header\"><code>notebook2script</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L419\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"notebook2script\" class=\"doc_header\"><code>notebook2script</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L430\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>notebook2script</code>(**`fname`**=*`None`*, **`silent`**=*`False`*, **`to_dict`**=*`False`*, **`bare`**=*`False`*)\n",
        "\n",
@@ -1671,6 +1674,46 @@
     "def t(a,export):\n",
     "    \"Test func that uses 'export' as a parameter name and has `export` in its doc string\"\n",
     "assert '[`export`](/export.html)' not in show_doc(t, disp=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "unterminated string literal (detected at line 18) (302778735.py, line 18)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  Input \u001b[0;32mIn [91]\u001b[0;36m\u001b[0m\n\u001b[0;31m    '<h2 id=\"A\" class=\"doc_header\"><code>class</code> <code>A</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\\n\\n> <code>A</code>(**`a`**:`int`=*`2`*, **`b`**:`Sequence`\\\\[`int`\\\\]=*`(1, 2, 3)`*)\\n\\nTest dataclass''''\u001b[0m\n\u001b[0m                                                                                                                                                                                                                                                   ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m unterminated string literal (detected at line 18)\n"
+     ]
+    }
+   ],
+   "source": [
+    "#hide\n",
+    "from typing import Sequence\n",
+    "\n",
+    "@dataclass\n",
+    "class A:\n",
+    "    \"Test dataclass\"\n",
+    "    a:int = 2 # First\n",
+    "    b:Sequence[int] = (1,2,3)  # Second\n",
+    "\n",
+    "    def test(self, \n",
+    "        c:int = 1, # it's a test\n",
+    "        d:str = 'test' # it's a second test\n",
+    "    )->str: # it's a return string\n",
+    "        return d\n",
+    "\n",
+    "# import test\n",
+    "tst_str = '''\n",
+    "'<h2 id=\"A\" class=\"doc_header\"><code>class</code> <code>A</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\\n\\n> <code>A</code>(**`a`**:`int`=*`2`*, **`b`**:`Sequence`\\\\[`int`\\\\]=*`(1, 2, 3)`*)\\n\\nTest dataclass'\n",
+    "'''\n",
+    "show_doc(A, disp=False)\n",
+    "# show_doc(test.A2)\n",
+    "# show_doc(A.test)\n",
+    "# docments(A.test)"
    ]
   },
   {
@@ -2005,7 +2048,7 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.4 64-bit",
    "language": "python",
    "name": "python3"
   }

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -1706,14 +1706,10 @@
     "    )->str: # it's a return string\n",
     "        return d\n",
     "\n",
-    "# import test\n",
     "tst_str = '''\n",
-    "'<h2 id=\"A\" class=\"doc_header\"><code>class</code> <code>A</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\\n\\n> <code>A</code>(**`a`**:`int`=*`2`*, **`b`**:`Sequence`\\\\[`int`\\\\]=*`(1, 2, 3)`*)\\n\\nTest dataclass'\n",
+    "<h2 id=\"A\" class=\"doc_header\"><code>class</code> <code>A</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\\n\\n> <code>A</code>(**`a`**:`int`=*`2`*, **`b`**:`Sequence`\\\\[`int`\\\\]=*`(1, 2, 3)`*)\\n\\nTest dataclass\n",
     "'''\n",
-    "show_doc(A, disp=False)\n",
-    "# show_doc(test.A2)\n",
-    "# show_doc(A.test)\n",
-    "# docments(A.test)"
+    "show_doc(A, disp=False)"
    ]
   },
   {
@@ -2048,7 +2044,7 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3.10.4 64-bit",
+   "display_name": "Python 3.9.12 ('nbdev_env')",
    "language": "python",
    "name": "python3"
   }

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -1680,16 +1680,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "SyntaxError",
-     "evalue": "unterminated string literal (detected at line 18) (302778735.py, line 18)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;36m  Input \u001b[0;32mIn [91]\u001b[0;36m\u001b[0m\n\u001b[0;31m    '<h2 id=\"A\" class=\"doc_header\"><code>class</code> <code>A</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\\n\\n> <code>A</code>(**`a`**:`int`=*`2`*, **`b`**:`Sequence`\\\\[`int`\\\\]=*`(1, 2, 3)`*)\\n\\nTest dataclass''''\u001b[0m\n\u001b[0m                                                                                                                                                                                                                                                   ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m unterminated string literal (detected at line 18)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#hide\n",
     "from typing import Sequence\n",
@@ -1706,10 +1697,8 @@
     "    )->str: # it's a return string\n",
     "        return d\n",
     "\n",
-    "tst_str = '''\n",
-    "<h2 id=\"A\" class=\"doc_header\"><code>class</code> <code>A</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\\n\\n> <code>A</code>(**`a`**:`int`=*`2`*, **`b`**:`Sequence`\\\\[`int`\\\\]=*`(1, 2, 3)`*)\\n\\nTest dataclass\n",
-    "'''\n",
-    "show_doc(A, disp=False)"
+    "tst_str = '''<h2 id=\"A\" class=\"doc_header\"><code>class</code> <code>A</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\\n\\n> <code>A</code>(**`a`**:`int`=*`2`*, **`b`**:`Sequence`\\\\[`int`\\\\]=*`(1, 2, 3)`*)\\n\\nTest dataclass'''\n",
+    "assert tst_str == show_doc(A, disp=False)"
    ]
   },
   {
@@ -1727,7 +1716,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h2 id=\"DocsTestClass\" class=\"doc_header\"><code>class</code> <code>DocsTestClass</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L435\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\n",
+       "<h2 id=\"DocsTestClass\" class=\"doc_header\"><code>class</code> <code>DocsTestClass</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L446\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\n",
        "\n",
        "> <code>DocsTestClass</code>()\n",
        "\n",
@@ -1754,7 +1743,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"DocsTestClass.test\" class=\"doc_header\"><code>DocsTestClass.test</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L437\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"DocsTestClass.test\" class=\"doc_header\"><code>DocsTestClass.test</code><a href=\"https://github.com/fastai/nbdev/tree/master/nbdev/export.py#L448\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>DocsTestClass.test</code>()\n",
        "\n"

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -816,7 +816,7 @@
     "#|export\n",
     "def _has_docment(elt): \n",
     "    comments = {o.start[0]:_clean_comment(o.string) for o in _tokens(elt) if o.type==COMMENT}\n",
-    "    params = _param_locs(elt, returns=True)\n",
+    "    params = _param_locs(elt, returns=True) or {}\n",
     "    comments = [_get_comment(line,arg,comments,params) for line,arg in params.items()]\n",
     "    return any(c is not None for c in comments)"
    ]
@@ -1534,8 +1534,7 @@
     "            # dataclass doesn't have accessible __init__\n",
     "            elt = elt.__init__\n",
     "        if is_source_available(elt):\n",
-    "            if not is_dataclass(elt) and (show_all_docments or _has_docment(elt)):\n",
-    "                # temporary fix for dataclass definition until `docments` is fixed\n",
+    "            if show_all_docments or _has_docment(elt):\n",
     "                if hasattr(elt, \"__delwrap__\"):\n",
     "                    arg_dict, kwargs = _handle_delegates(elt)\n",
     "                    doc += _get_docments(elt, ment_dict=arg_dict, with_return=True, kwargs=kwargs, monospace=monospace, is_class=is_class)\n",
@@ -1699,6 +1698,38 @@
     "\n",
     "tst_str = '''<h2 id=\"A\" class=\"doc_header\"><code>class</code> <code>A</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\\n\\n> <code>A</code>(**`a`**:`int`=*`2`*, **`b`**:`Sequence`\\\\[`int`\\\\]=*`(1, 2, 3)`*)\\n\\nTest dataclass'''\n",
     "assert tst_str == show_doc(A, disp=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#hide\n",
+    "tmp = Path('temp.py')\n",
+    "tmp.write_text(\"\"\"\n",
+    "from typing import Sequence\n",
+    "from dataclasses import dataclass\n",
+    "@dataclass\n",
+    "class A:\n",
+    "    \"Test dataclass\"\n",
+    "    a:int = 2 # First argument\n",
+    "    b:Sequence[int] = (1,2,3)  # Second argument\n",
+    "\n",
+    "    def test(self, \n",
+    "        c:int = 1, # it's a test\n",
+    "        d:str = 'test' # it's a second test\n",
+    "    )->str: # it's a return string\n",
+    "        return d\n",
+    "\"\"\")\n",
+    "import temp\n",
+    "tst_str = '<h2 id=\"A\" class=\"doc_header\"><code>class</code> <code>A</code><a href=\"temp.py#L4\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\\n\\n> <code>A</code>(**`a`**:`int`=*`2`*, **`b`**:`Sequence`\\\\[`int`\\\\]=*`(1, 2, 3)`*)\\n\\nTest dataclass\\n\\n||Type|Default|Details|\\n|---|---|---|---|\\n|**`a`**|`int`|`2`|First argument|\\n|**`b`**|`typing.Sequence[int]`|`(1, 2, 3)`|Second argument|\\n'\n",
+    "assert tst_str == show_doc(temp.A, disp=False)\n",
+    "try:\n",
+    "    tmp.unlink()\n",
+    "except FileNotFoundError:\n",
+    "    pass"
    ]
   },
   {
@@ -2033,7 +2064,7 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3.9.12 ('nbdev_env')",
+   "display_name": "Python 3.9.12 ('base')",
    "language": "python",
    "name": "python3"
   }


### PR DESCRIPTION
`show_doc` couldn't show dataclasses (see for example #595). The problem is to show class, nbdev actually shows its constructor and dataclass doesn't have an accessible one. The PR temporary fixes this. The remaining problem is class level docments and class constructor arguments docments are not shown. This needs to be treated in fastcore.docments.