### PR TITLE
Update min fastcore requirement

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ status = 4
 min_python = 3.7
 audience = Developers
 language = English
-requirements = fastcore>=1.4.1 nbformat>=4.4.0 nbconvert>=6.1 pyyaml jupyter jupyter_client<8 ipykernel ghapi fastrelease Jinja2
+requirements = fastcore>=1.4.5 nbformat>=4.4.0 nbconvert>=6.1 pyyaml jupyter jupyter_client<8 ipykernel ghapi fastrelease Jinja2
 console_scripts = nbdev_build_lib=nbdev.export2html:nbdev_build_lib
 	nbdev_update_lib=nbdev.sync:nbdev_update_lib
 	nbdev_diff_nbs=nbdev.sync:nbdev_diff_nbs


### PR DESCRIPTION
nbdev requires newer fastcore version >= [1.4.5](https://github.com/fastai/fastcore/releases/tag/1.4.5) to build lib, due to docments changes

With fastcore v1.4.4 command `nbdev_build_docs` raises error:
```
Traceback (most recent call last):
  File "/usr/local/bin/nbdev_build_lib", line 5, in <module>
    from nbdev.export2html import nbdev_build_lib
  File "/usr/local/lib/python3.7/dist-packages/nbdev/export2html.py", line 15, in <module>
    from .showdoc import *
  File "/usr/local/lib/python3.7/dist-packages/nbdev/showdoc.py", line 12, in <module>
    from fastcore.docments import _docments, isclass, _clean_comment, _tokens, _param_locs, _get_comment
ImportError: cannot import name '_docments' from 'fastcore.docments' (/usr/local/lib/python3.7/dist-packages/fastcore/docments.py)
```