### PR TITLE
fix show_doc for properties

### DIFF
--- a/nbdev/export.py
+++ b/nbdev/export.py
@@ -452,6 +452,9 @@ class DocsTestClass:
     @classmethod
     def test_cls(cls, arg): pass
 
+    @property
+    def test_property(self): pass
+
 # Internal Cell
 #exporti
 #for tests only

--- a/nbs/00_export.ipynb
+++ b/nbs/00_export.ipynb
@@ -1821,7 +1821,10 @@
     "    def test_self(self, cls, arg): pass\n",
     "\n",
     "    @classmethod\n",
-    "    def test_cls(cls, arg): pass"
+    "    def test_cls(cls, arg): pass\n",
+    "    \n",
+    "    @property\n",
+    "    def test_property(self): pass"
    ]
   },
   {

--- a/nbs/02_showdoc.ipynb
+++ b/nbs/02_showdoc.ipynb
@@ -1509,18 +1509,14 @@
     "    elt = getattr(elt, '__func__', elt)\n",
     "    qname = name or qual_name(elt)\n",
     "    is_class = inspect.isclass(elt)\n",
-    "    is_class_member = '.' in qname or inspect.isclass(elt)\n",
-    "    if is_class_member:\n",
-    "        if is_enum(elt): name,args = _format_enum_doc(elt, qname)\n",
-    "        elif inspect.isclass(elt): name,args = _format_cls_doc(elt, qname)\n",
-    "        # if it's a class method or a regular object method, we want to skip\n",
-    "        # the `self` or `cls` 1st arg from the docs.\n",
-    "        elif callable(elt):\n",
-    "            name,args = _format_func_doc(elt, qname, skip_params=('self', 'cls'))\n",
-    "    # for a regular function don't skip 'self' or 'cls'.\n",
+    "    is_class_member = '.' in qname\n",
+    "    if is_class:\n",
+    "        if is_enum(elt):    name,args = _format_enum_doc(elt, qname)\n",
+    "        else:               name,args = _format_cls_doc (elt, qname)\n",
     "    elif callable(elt):\n",
-    "        name,args = _format_func_doc(elt, qname)\n",
-    "    else:                name,args = f\"<code>{qname}</code>\", ''\n",
+    "        if is_class_member: name,args = _format_func_doc(elt, qname, skip_params=('self', 'cls'))\n",
+    "        else:               name,args = _format_func_doc(elt, qname)\n",
+    "    else:                   name,args = f\"<code>{qname}</code>\", ''\n",
     "    link = get_source_link(elt)\n",
     "    source_link = f'<a href=\"{link}\" class=\"source_link\" style=\"float:right\">[source]</a>'\n",
     "    title_level = title_level or (default_cls_level if inspect.isclass(elt) else 4)\n",
@@ -1542,11 +1538,12 @@
     "            elt = elt.__init__\n",
     "        if is_source_available(elt):\n",
     "            if show_all_docments or _has_docment(elt):\n",
+    "                skip_self_cls = is_class_member or is_class\n",
     "                if hasattr(elt, \"__delwrap__\"):\n",
     "                    arg_dict, kwargs = _handle_delegates(elt)\n",
-    "                    doc += _get_docments(elt, ment_dict=arg_dict, with_return=True, kwargs=kwargs, monospace=monospace, is_class=is_class_member)\n",
+    "                    doc += _get_docments(elt, ment_dict=arg_dict, with_return=True, kwargs=kwargs, monospace=monospace, is_class=skip_self_cls)\n",
     "                else:\n",
-    "                    doc += _get_docments(elt, monospace=monospace, is_class=is_class_member)\n",
+    "                    doc += _get_docments(elt, monospace=monospace, is_class=skip_self_cls)\n",
     "            elif verbose:\n",
     "                print(f'Warning: `docments` annotations will not work for built-in modules, classes, functions, and `enums` and are unavailable for {qual_name(elt)}. They will not be shown')\n",
     "    if disp: display(Markdown(doc))\n",
@@ -1809,6 +1806,30 @@
    "source": [
     "#|hide\n",
     "show_doc(DocsTestClass.test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"DocsTestClass.test_property\" class=\"doc_header\"><code>DocsTestClass.test_property</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#|hide\n",
+    "show_doc(DocsTestClass.test_property)"
    ]
   },
   {


### PR DESCRIPTION
This fixes `show_doc` for properties, and adds a smoke test. There's a missing `else` branch in the nested if statements.

nbdev + fastcore + fastai tests pass locally.

cc @hamelsmu @jph00