### PR TITLE
Add early return

### DIFF
--- a/nbdev/clean.py
+++ b/nbdev/clean.py
@@ -99,7 +99,7 @@ def nbdev_clean(
     # Git hooks will pass the notebooks in stdin
     _clean = partial(clean_nb, clear_all=clear_all)
     _write = partial(process_write, warn_msg='Failed to clean notebook', proc_nb=_clean)
-    if stdin: _write(f_in=sys.stdin, f_out=sys.stdout)
+    if stdin: return _write(f_in=sys.stdin, f_out=sys.stdout)
     
     if fname is None: fname = config_key("nbs_path", '.', missing_ok=True)
     for f in globtastic(fname, file_glob='*.ipynb', skip_folder_re='^[_.]'): _write(f_in=f, disp=disp)

--- a/nbs/11_clean.ipynb
+++ b/nbs/11_clean.ipynb
@@ -229,7 +229,7 @@
     "    # Git hooks will pass the notebooks in stdin\n",
     "    _clean = partial(clean_nb, clear_all=clear_all)\n",
     "    _write = partial(process_write, warn_msg='Failed to clean notebook', proc_nb=_clean)\n",
-    "    if stdin: _write(f_in=sys.stdin, f_out=sys.stdout)\n",
+    "    if stdin: return _write(f_in=sys.stdin, f_out=sys.stdout)\n",
     "    \n",
     "    if fname is None: fname = config_key(\"nbs_path\", '.', missing_ok=True)\n",
     "    for f in globtastic(fname, file_glob='*.ipynb', skip_folder_re='^[_.]'): _write(f_in=f, disp=disp)"


### PR DESCRIPTION
It seems like there is a missing return statement when reading from stdin.

The current code reads from stdin and writes to stdout, but then proceeds to
running through all notebook files via globbing and processing all of them.

When git builds the index (happens even during git status) it passes all
files to the filter each via stdin which leads to n^2 behavior where n
is the number of notebooks.

@jph00 