### PR TITLE
Fix nbdev_install_hooks references in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ strive to abide by generally accepted best practices in open-source
 software development.
 
 Make sure you have `nbdev`’s git hooks installed by running
-`nbdev_install_git_hooks` in the cloned repository.
+[nbdev_install_hooks](https://nbdev.fast.ai/clean.html#nbdev_install_hooks)
+in the cloned repository.
 
 ## Copyright
 

--- a/nbs/11_clean.ipynb
+++ b/nbs/11_clean.ipynb
@@ -55,7 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To avoid pointless conflicts while working with jupyter notebooks (with different execution counts or cell metadata), it is recommended to clean the notebooks before committing anything (done automatically if you install the git hooks with `nbdev_install_git_hooks`). The following functions are used to do that."
+    "To avoid pointless conflicts while working with jupyter notebooks (with different execution counts or cell metadata), it is recommended to clean the notebooks before committing anything (done automatically if you install the git hooks with `nbdev_install_hooks`). The following functions are used to do that."
    ]
   },
   {

--- a/nbs/getting_started.ipynb
+++ b/nbs/getting_started.ipynb
@@ -181,7 +181,7 @@
    "source": [
     "If you want to contribute to `nbdev`, be sure to review the [contributions guidelines](https://github.com/fastai/nbdev/blob/master/CONTRIBUTING.md). This project adheres to fastai's [code of conduct](https://github.com/fastai/nbdev/blob/master/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. In general, we strive to abide by generally accepted best practices in open-source software development.\n",
     "\n",
-    "Make sure you have `nbdev`'s git hooks installed by running `nbdev_install_git_hooks` in the cloned repository."
+    "Make sure you have `nbdev`'s git hooks installed by running `nbdev_install_hooks` in the cloned repository."
    ]
   },
   {


### PR DESCRIPTION
Changed a couple of references to the old `nbdev_install_git_hooks` instead of `nbdev_install_hooks`.

Some issue still remains when previewing the documentation with `nbdev_preview`, all notebooks are stripped of the numbering prefix, except for `11_clean.ipynb`. (See screenshots below), which breaks the autogenerated cross references in the docs (which point to `clean.html` instead of `11_clean.html`)
<img width="199" alt="Screenshot 2022-07-29 at 12 25 55" src="https://user-images.githubusercontent.com/69843715/181749304-3041ba13-f1b1-4519-a9d1-3bb97527d190.png">
<img width="229" alt="Screenshot 2022-07-29 at 12 27 14" src="https://user-images.githubusercontent.com/69843715/181749517-f047aba8-c272-418a-92ef-c5dedc00263c.png">

I haven't been able to locate why that's going on yet.