### PR TITLE
enable mac terminal install instead of visual installer

### DIFF
--- a/nbdev/shortcuts.py
+++ b/nbdev/shortcuts.py
@@ -29,7 +29,7 @@ def _install_linux():
     
 def _install_mac():
     system(f'curl -LO {BASE_QUARTO_URL}quarto-macos.pkg')
-    system('sudo installer -pkg quarto-macos.pkg -target /usr/local/bin/quarto')
+    system('sudo installer -pkg quarto-macos.pkg -target ~/')
 
 def install_quarto():
     "Install latest Quarto on macOS or Linux, prints instructions for Windows"

--- a/nbdev/shortcuts.py
+++ b/nbdev/shortcuts.py
@@ -29,7 +29,7 @@ def _install_linux():
     
 def _install_mac():
     system(f'curl -LO {BASE_QUARTO_URL}quarto-macos.pkg')
-    system('open quarto-macos.pkg')
+    system('sudo installer -pkg quarto-macos.pkg -target /usr/local/bin/quarto')
 
 def install_quarto():
     "Install latest Quarto on macOS or Linux, prints instructions for Windows"

--- a/nbdev/shortcuts.py
+++ b/nbdev/shortcuts.py
@@ -29,7 +29,7 @@ def _install_linux():
     
 def _install_mac():
     system(f'curl -LO {BASE_QUARTO_URL}quarto-macos.pkg')
-    system('sudo installer -pkg quarto-macos.pkg -target ~/')
+    system('sudo installer -pkg quarto-macos.pkg -target /')
 
 def install_quarto():
     "Install latest Quarto on macOS or Linux, prints instructions for Windows"

--- a/nbs/16_shortcuts.ipynb
+++ b/nbs/16_shortcuts.ipynb
@@ -67,7 +67,7 @@
     "    \n",
     "def _install_mac():\n",
     "    system(f'curl -LO {BASE_QUARTO_URL}quarto-macos.pkg')\n",
-    "    system('open quarto-macos.pkg')\n",
+    "    system('sudo installer -pkg quarto-macos.pkg -target /usr/local/bin/quarto')\n",
     "\n",
     "def install_quarto():\n",
     "    \"Install latest Quarto on macOS or Linux, prints instructions for Windows\"\n",

--- a/nbs/16_shortcuts.ipynb
+++ b/nbs/16_shortcuts.ipynb
@@ -67,7 +67,7 @@
     "    \n",
     "def _install_mac():\n",
     "    system(f'curl -LO {BASE_QUARTO_URL}quarto-macos.pkg')\n",
-    "    system('sudo installer -pkg quarto-macos.pkg -target /usr/local/bin/quarto')\n",
+    "    system('sudo installer -pkg quarto-macos.pkg -target ~/')\n",
     "\n",
     "def install_quarto():\n",
     "    \"Install latest Quarto on macOS or Linux, prints instructions for Windows\"\n",

--- a/nbs/16_shortcuts.ipynb
+++ b/nbs/16_shortcuts.ipynb
@@ -67,7 +67,7 @@
     "    \n",
     "def _install_mac():\n",
     "    system(f'curl -LO {BASE_QUARTO_URL}quarto-macos.pkg')\n",
-    "    system('sudo installer -pkg quarto-macos.pkg -target ~/')\n",
+    "    system('sudo installer -pkg quarto-macos.pkg -target /')\n",
     "\n",
     "def install_quarto():\n",
     "    \"Install latest Quarto on macOS or Linux, prints instructions for Windows\"\n",


### PR DESCRIPTION
This is needed for CI to install quarto for mac

This will close https://github.com/fastai/nbdev/issues/425