### PR TITLE
Update link to migration guide

### DIFF
--- a/nbs/getting_started.ipynb
+++ b/nbs/getting_started.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*NB: This is nbdev v2, a major upgrade of nbdev. Whilst the differences to nbdev1 aren't huge, it does require some changes. The old version docs are at [nbdev1.fast.ai](https://nbdev1.fast.ai). You can use version-pinning in `settings.ini` (i.e `'nbdev<2'`) to stop nbdev from upgrading. To upgrade, follow the [migration tutorial](https://nbdev.fast.ai/migrate.html).*\n",
+    "*NB: This is nbdev v2, a major upgrade of nbdev. Whilst the differences to nbdev1 aren't huge, it does require some changes. The old version docs are at [nbdev1.fast.ai](https://nbdev1.fast.ai). You can use version-pinning in `settings.ini` (i.e `'nbdev<2'`) to stop nbdev from upgrading. To upgrade, follow the [migration tutorial](https://nbdev.fast.ai/migrating.html).*\n",
     "\n",
     "---\n",
     "\n",


### PR DESCRIPTION
Updated link on getting starting page to point to migrating guide instead of migrate module docs.