### PR TITLE
add `user` option to `jupyter_hooks` setting

### DIFF
--- a/nbs/11_clean.ipynb
+++ b/nbs/11_clean.ipynb
@@ -335,23 +335,34 @@
     "#|export\n",
     "def clean_jupyter(path, model, **kwargs):\n",
     "    \"Clean Jupyter `model` pre save to `path`\"\n",
-    "    get_config.cache_clear() # Reset Jupyter's cache\n",
+    "    get_config.cache_clear() # Allow config changes without restarting Jupyter\n",
     "    try: cfg = get_config(path=path)\n",
-    "    except FileNotFoundError: return\n",
+    "    except FileNotFoundError: cfg = {}\n",
+    "\n",
+    "    jupyter_hooks = cfg.get('jupyter_hooks', 'user')\n",
+    "    try: jupyter_hooks = str2bool(jupyter_hooks)\n",
+    "    except ValueError: pass\n",
+    "    else:\n",
+    "        warn((\"Boolean-valued `jupyter_hooks` is deprecated. Use one of `{'user','nbdev','none'} instead.\\n\"\n",
+    "              \"See the docs for more: https://nbdev.fast.ai/clean.html#clean_jupyter\"), DeprecationWarning)\n",
+    "        jupyter_hooks = 'nbdev' if jupyter_hooks else 'none'\n",
+    "\n",
+    "    if not (model['type']=='notebook' and model['content']['nbformat']==4): return\n",
     "    in_nbdev_repo = 'nbs_path' in cfg\n",
-    "    jupyter_hooks = str2bool(cfg.get('jupyter_hooks', True))\n",
-    "    if model['type'] != 'notebook': return\n",
-    "    is_nb_v4 = model['content']['nbformat'] == 4\n",
-    "    if in_nbdev_repo and jupyter_hooks and is_nb_v4: _nbdev_clean(model['content'])"
+    "    if jupyter_hooks=='user' or (jupyter_hooks=='nbdev' and in_nbdev_repo): _nbdev_clean(model['content'])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This implements Jupyter's [`ContentsManager.pre_save_hook`](https://jupyter-notebook.readthedocs.io/en/6.4.12/extending/savehooks.html). The easiest way to install it for Jupyter Notebook and Lab is by running  `nbdev_install_hooks`.\n",
+    "This implements a `pre_save_hook` from Jupyter's [file save hook API](https://jupyter-server.readthedocs.io/en/latest/developers/savehooks.html). The easiest way to install it for both Jupyter Notebook and Lab is by running  `nbdev_install_hooks`.\n",
     "\n",
-    "It only runs on notebooks in an `nbdev` repo. You can disable it for an nbdev repo at any time by setting `jupyter_hooks = False` in `settings.ini`."
+    "The `jupyter_hooks` key in your `settings.ini` controls when hooks are run, accepting:\n",
+    "\n",
+    "- `nbdev` (default): Only on notebooks in `nbdev` repos\n",
+    "- `user`: All notebooks for this user\n",
+    "- `none`: Never"
    ]
   },
   {


### PR DESCRIPTION
Note that this isn't yet useful. I'm considering changing `get_config` to read `~/.nbdev/settings.ini` if it exists, then `update` it with `$(pwd)/settings.ini`, then `jupyter_hooks=user` will be useful. @hamelsmu @jph00 what do you think?