### PR TITLE
Revert "fix #753"

### DIFF
--- a/nbdev/merge.py
+++ b/nbdev/merge.py
@@ -100,9 +100,6 @@ def _git_merge_file(base, ours, theirs):
 @call_parse
 def nbdev_merge(base:str, ours:str, theirs:str, path:str):
     "Git merge driver for notebooks"
-    print(f'Auto-merging {path}')
     if not _git_merge_file(base, ours, theirs).returncode: return
     theirs = str2bool(os.environ.get('THEIRS', False))
-    conflict = _nbdev_fix(ours, theirs=theirs, noprint=True)
-    if conflict: print(f'CONFLICT (content): Merge conflict in {path}')
-    return conflict
+    return _nbdev_fix(ours, theirs=theirs)

--- a/nbs/06_merge.ipynb
+++ b/nbs/06_merge.ipynb
@@ -503,12 +503,9 @@
     "@call_parse\n",
     "def nbdev_merge(base:str, ours:str, theirs:str, path:str):\n",
     "    \"Git merge driver for notebooks\"\n",
-    "    print(f'Auto-merging {path}')\n",
     "    if not _git_merge_file(base, ours, theirs).returncode: return\n",
     "    theirs = str2bool(os.environ.get('THEIRS', False))\n",
-    "    conflict = _nbdev_fix(ours, theirs=theirs, noprint=True)\n",
-    "    if conflict: print(f'CONFLICT (content): Merge conflict in {path}')\n",
-    "    return conflict"
+    "    return _nbdev_fix(ours, theirs=theirs)"
    ]
   },
   {


### PR DESCRIPTION
My bad, idk why I thought it wasn't already printing like `git merge` - the reverted commit makes it double print.