### PR TITLE
preview quarto default to random port

### DIFF
--- a/nbdev/cli.py
+++ b/nbdev/cli.py
@@ -221,7 +221,6 @@ project:
   type: website
   output-dir: {doc_path}
   preview:
-    port: 3000
     browser: false
 
 format:


### PR DESCRIPTION
To avoid

```sh
nbdev_preview 
```

```sh
ERROR: Requested port 3000 is already in use.
```

Its seems neat to just omitted the port and [preview](https://quarto.org/docs/reference/projects/options.html#preview) with by default Port to random value between 3000 and 8000).