### PR TITLE
Hooks ignore settings.ini if Jupyter is started outside nbdev repo

### DIFF
--- a/nbdev/clean.py
+++ b/nbdev/clean.py
@@ -98,9 +98,10 @@ def process_write(warn_msg, proc_nb, f_in, f_out=None, disp=False):
         warn(e)
 
 # %% ../nbs/11_clean.ipynb 23
-def _nbdev_clean(nb, **kwargs):
-    allowed_metadata_keys = config_key("allowed_metadata_keys", path=False).split()
-    allowed_cell_metadata_keys = config_key("allowed_cell_metadata_keys", path=False).split()
+def _nbdev_clean(nb, path=None, **kwargs):
+    cfg = get_config(path=path)
+    allowed_metadata_keys = cfg.get("allowed_metadata_keys").split()
+    allowed_cell_metadata_keys = cfg.get("allowed_cell_metadata_keys").split()
     return clean_nb(nb, allowed_metadata_keys=allowed_metadata_keys,
                     allowed_cell_metadata_keys=allowed_cell_metadata_keys, **kwargs)
 
@@ -132,7 +133,8 @@ def clean_jupyter(path, model, **kwargs):
               "See the docs for more: https://nbdev.fast.ai/clean.html#clean_jupyter"), DeprecationWarning)
         jupyter_hooks = False if jupyter_hooks == 'none' else True
     else: jupyter_hooks = str2bool(jupyter_hooks)
-    if jupyter_hooks: _nbdev_clean(model['content'])
+    if jupyter_hooks: _nbdev_clean(model['content'], path=path)
+
 
 # %% ../nbs/11_clean.ipynb 30
 _pre_save_hook_src = '''

--- a/nbs/11_clean.ipynb
+++ b/nbs/11_clean.ipynb
@@ -295,9 +295,10 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def _nbdev_clean(nb, **kwargs):\n",
-    "    allowed_metadata_keys = config_key(\"allowed_metadata_keys\", path=False).split()\n",
-    "    allowed_cell_metadata_keys = config_key(\"allowed_cell_metadata_keys\", path=False).split()\n",
+    "def _nbdev_clean(nb, path=None, **kwargs):\n",
+    "    cfg = get_config(path=path)\n",
+    "    allowed_metadata_keys = cfg.get(\"allowed_metadata_keys\").split()\n",
+    "    allowed_cell_metadata_keys = cfg.get(\"allowed_cell_metadata_keys\").split()\n",
     "    return clean_nb(nb, allowed_metadata_keys=allowed_metadata_keys,\n",
     "                    allowed_cell_metadata_keys=allowed_cell_metadata_keys, **kwargs)"
    ]
@@ -366,7 +367,7 @@
     "              \"See the docs for more: https://nbdev.fast.ai/clean.html#clean_jupyter\"), DeprecationWarning)\n",
     "        jupyter_hooks = False if jupyter_hooks == 'none' else True\n",
     "    else: jupyter_hooks = str2bool(jupyter_hooks)\n",
-    "    if jupyter_hooks: _nbdev_clean(model['content'])"
+    "    if jupyter_hooks: _nbdev_clean(model['content'], path=path)\n"
    ]
   },
   {


### PR DESCRIPTION
Jupyter hooks are run from Jupyter's cwd (can be specified or else directory Jupyter was launched from). Test this by launching Jupyter from outside your current project's directory.

When this isn't the same directory as the nbdev repos root directory the settings file is not found.
Because some settings have default values e.g. allowed_metadata_keys the hook doesn't fail when the settings file is missing.

Instead we look at the path of the notebook given to the hook and attempt to find the settings file by
traversing directories upward until we find it or hit root '/'.

@jph00 @seeM 