### PR TITLE
Clean `id` from text `repr` outputs to further avoid git merge conflicts

### DIFF
--- a/nbdev/_modidx.py
+++ b/nbdev/_modidx.py
@@ -7,6 +7,7 @@ d = { 'settings': { 'allowed_cell_metadata_keys': '',
                 'author_email': 'j@fast.ai',
                 'black_formatting': 'False',
                 'branch': 'master',
+                'clean_ids': 'True',
                 'conda_requirements': 'pyyaml',
                 'console_scripts': 'nbdev_create_config=nbdev.read:nbdev_create_config\n'
                                    'nbdev_update=nbdev.sync:nbdev_update\n'

--- a/nbdev/read.py
+++ b/nbdev/read.py
@@ -62,6 +62,7 @@ def apply_defaults(
     allowed_metadata_keys='', # Preserve the list of keys in the main notebook metadata
     allowed_cell_metadata_keys='', # Preserve the list of keys in cell level metadata
     jupyter_hooks=True, # Run Jupyter hooks?
+    clean_ids=True, # Remove ids from plaintext reprs?
 ):
     "Apply default settings where missing in `cfg`"
     if lib_name is None:

--- a/nbs/01_read.ipynb
+++ b/nbs/01_read.ipynb
@@ -171,6 +171,7 @@
     "    allowed_metadata_keys='', # Preserve the list of keys in the main notebook metadata\n",
     "    allowed_cell_metadata_keys='', # Preserve the list of keys in cell level metadata\n",
     "    jupyter_hooks=True, # Run Jupyter hooks?\n",
+    "    clean_ids=True, # Remove ids from plaintext reprs?\n",
     "):\n",
     "    \"Apply default settings where missing in `cfg`\"\n",
     "    if lib_name is None:\n",

--- a/nbs/11_clean.ipynb
+++ b/nbs/11_clean.ipynb
@@ -122,13 +122,24 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def _clean_cell_output(cell):\n",
-    "    \"Remove execution count in `cell`\"\n",
-    "    if 'outputs' in cell:\n",
-    "        for o in cell['outputs']:\n",
-    "            if 'execution_count' in o: o['execution_count'] = None\n",
-    "            o.get('data',{}).pop(\"application/vnd.google.colaboratory.intrinsic+json\", None)\n",
-    "            o.get('metadata', {}).pop('tags', None)"
+    "_repr_id_re = re.compile('(<.*?)( at 0x[0-9a-fA-F]+)(>)')\n",
+    "\n",
+    "def _clean_cell_output_id(lines): return [_repr_id_re.sub(r'\\1\\3', o) for o in lines]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#|hide\n",
+    "test_eq(_clean_cell_output_id(['Lambda(func=<function _add2 at 0x7f8252378820>)',\n",
+    "                               '[<PIL.Image.Image image mode=RGB size=320x240 at 0x7FAC4E2CF610>,\\n',\n",
+    "                               '(<a at 0x7f8252378820>, <b at 0x7EFE94247550>, <c at 0x7f8252378820>)']),\n",
+    "                              ['Lambda(func=<function _add2>)',\n",
+    "                               '[<PIL.Image.Image image mode=RGB size=320x240>,\\n',\n",
+    "                               '(<a>, <b>, <c>)'])"
    ]
   },
   {
@@ -138,12 +149,33 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def _clean_cell(cell, clear_all=False, allowed_metadata_keys=None):\n",
+    "def _clean_cell_output(cell, clean_ids):\n",
+    "    \"Remove `cell` output execution count and optionally ids from text reprs\"\n",
+    "    outputs = cell.get('outputs', [])\n",
+    "    for o in outputs:\n",
+    "        if 'execution_count' in o: o['execution_count'] = None\n",
+    "        data = o.get('data', {})\n",
+    "        data.pop(\"application/vnd.google.colaboratory.intrinsic+json\", None)\n",
+    "        if clean_ids:\n",
+    "            for k in data:\n",
+    "                if k.startswith('text'): data[k] = _clean_cell_output_id(data[k])\n",
+    "            if 'text' in o: o['text'] = _clean_cell_output_id(o['text'])\n",
+    "        o.get('metadata', {}).pop('tags', None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#|export\n",
+    "def _clean_cell(cell, clear_all, allowed_metadata_keys, clean_ids):\n",
     "    \"Clean `cell` by removing superfluous metadata or everything except the input if `clear_all`\"\n",
     "    if 'execution_count' in cell: cell['execution_count'] = None\n",
     "    if 'outputs' in cell:\n",
     "        if clear_all: cell['outputs'] = []\n",
-    "        else:         _clean_cell_output(cell)\n",
+    "        else:         _clean_cell_output(cell, clean_ids)\n",
     "    if cell['source'] == ['']: cell['source'] = []\n",
     "    cell['metadata'] = {} if clear_all else {\n",
     "        k:v for k,v in cell['metadata'].items() if k in allowed_metadata_keys}"
@@ -160,14 +192,15 @@
     "    nb, # The notebook to clean\n",
     "    clear_all=False, # Remove all cell metadata and cell outputs\n",
     "    allowed_metadata_keys:list=None, # Preserve the list of keys in the main notebook metadata\n",
-    "    allowed_cell_metadata_keys:list=None # Preserve the list of keys in cell level metadata\n",
+    "    allowed_cell_metadata_keys:list=None, # Preserve the list of keys in cell level metadata\n",
+    "    clean_ids=True, # Remove ids from plaintext reprs?\n",
     "):\n",
     "    \"Clean `nb` from superfluous metadata\"\n",
     "    metadata_keys = {\"kernelspec\", \"jekyll\", \"jupytext\", \"doc\"}\n",
     "    if allowed_metadata_keys: metadata_keys.update(allowed_metadata_keys)\n",
     "    cell_metadata_keys = {\"hide_input\"}\n",
     "    if allowed_cell_metadata_keys: cell_metadata_keys.update(allowed_cell_metadata_keys)\n",
-    "    for c in nb['cells']: _clean_cell(c, clear_all=clear_all, allowed_metadata_keys=cell_metadata_keys)\n",
+    "    for c in nb['cells']: _clean_cell(c, clear_all, cell_metadata_keys, clean_ids)\n",
     "    nb['metadata'] = {k:v for k,v in nb['metadata'].items() if k in metadata_keys}"
    ]
   },
@@ -233,7 +266,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Passing the `clear_all=True` keyword removes everything from the cell metadata:"
+    "Passing `clear_all=True` removes everything from the cell metadata:"
    ]
   },
   {
@@ -250,6 +283,30 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Passing `clean_ids=True` removes `id`s from plaintext repr outputs, to avoid notebooks whose contents change on each run since they often lead to git merge conflicts. For example:\n",
+    "\n",
+    "```\n",
+    "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28 at 0x7FB4F8979690>\n",
+    "```\n",
+    "\n",
+    "becomes:\n",
+    "\n",
+    "```\n",
+    "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Commands -"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -259,13 +316,6 @@
     "def _reconfigure(*strms):\n",
     "    for s in strms:\n",
     "        if hasattr(s,'reconfigure'): s.reconfigure(encoding='utf-8')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Commands -"
    ]
   },
   {
@@ -299,7 +349,8 @@
     "    cfg = get_config(path=path)\n",
     "    allowed_metadata_keys = cfg.get(\"allowed_metadata_keys\").split()\n",
     "    allowed_cell_metadata_keys = cfg.get(\"allowed_cell_metadata_keys\").split()\n",
-    "    return clean_nb(nb, allowed_metadata_keys=allowed_metadata_keys,\n",
+    "    clean_ids = str2bool(cfg.get('clean_ids'))\n",
+    "    return clean_nb(nb, clean_ids=clean_ids, allowed_metadata_keys=allowed_metadata_keys,\n",
     "                    allowed_cell_metadata_keys=allowed_cell_metadata_keys, **kwargs)"
    ]
   },
@@ -331,7 +382,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default (`fname` left to `None`), the all the notebooks in `lib_folder` are cleaned. You can opt in to fully clean the notebook by removing every bit of metadata and the cell outputs by passing `clear_all=True`.\n",
+    "By default (`fname` left to `None`), all the notebooks in `lib_folder` are cleaned. You can opt in to fully clean the notebook by removing every bit of metadata and the cell outputs by passing `clear_all=True`.\n",
     "\n",
     "If you want to keep some keys in the main notebook metadata you can set `allowed_metadata_keys` in `settings.ini`.\n",
     "Similarly for cell level metadata use: `allowed_cell_metadata_keys`. For example, to preserve both `k1` and `k2` at both the notebook and cell level adding the following in `settings.ini`:\n",

--- a/nbs/tutorial.ipynb
+++ b/nbs/tutorial.ipynb
@@ -539,7 +539,7 @@
        "Do the saying"
       ],
       "text/plain": [
-       "<nbdev.showdoc.BasicMarkdownRenderer at 0x11595a6d0>"
+       "<nbdev.showdoc.BasicMarkdownRenderer>"
       ]
      },
      "execution_count": null,


### PR DESCRIPTION
It can be disabled using `clean_ids = False` in user- or project-settings. It can't yet be controlled per-notebook. I'd appreciate some guidance on how best to implement that, and thought it could be done in a follow-up PR.

Also tested by running `nbdev_clean` on fastai, then checking that `rg ' at 0x[0-9a-fA-F]+' nbs` finds nothing.

cc @hamelsmu @jph00