### PR TITLE
`clean_ids` corrupts string outputs

### DIFF
--- a/nbdev/clean.py
+++ b/nbdev/clean.py
@@ -47,7 +47,9 @@ def nbdev_trust(
 # %% ../nbs/11_clean.ipynb 9
 _repr_id_re = re.compile('(<.*?)( at 0x[0-9a-fA-F]+)(>)')
 
-def _clean_cell_output_id(lines): return [_repr_id_re.sub(r'\1\3', o) for o in lines]
+def _clean_cell_output_id(lines):
+    sub = partial(_repr_id_re.sub, r'\1\3')
+    return sub(lines) if isinstance(lines,str) else [sub(o) for o in lines]
 
 # %% ../nbs/11_clean.ipynb 11
 def _clean_cell_output(cell, clean_ids):

--- a/nbs/11_clean.ipynb
+++ b/nbs/11_clean.ipynb
@@ -124,7 +124,9 @@
     "#|export\n",
     "_repr_id_re = re.compile('(<.*?)( at 0x[0-9a-fA-F]+)(>)')\n",
     "\n",
-    "def _clean_cell_output_id(lines): return [_repr_id_re.sub(r'\\1\\3', o) for o in lines]"
+    "def _clean_cell_output_id(lines):\n",
+    "    sub = partial(_repr_id_re.sub, r'\\1\\3')\n",
+    "    return sub(lines) if isinstance(lines,str) else [sub(o) for o in lines]"
    ]
   },
   {
@@ -139,7 +141,8 @@
     "                               '(<a at 0x7f8252378820>, <b at 0x7EFE94247550>, <c at 0x7f8252378820>)']),\n",
     "                              ['Lambda(func=<function _add2>)',\n",
     "                               '[<PIL.Image.Image image mode=RGB size=320x240>,\\n',\n",
-    "                               '(<a>, <b>, <c>)'])"
+    "                               '(<a>, <b>, <c>)'])\n",
+    "test_eq(_clean_cell_output_id('foo\\n<function _add2 at 0x7f8252378820>\\nbar'), 'foo\\n<function _add2>\\nbar')"
    ]
   },
   {


### PR DESCRIPTION
For example: https://github.com/fastai/nbdev/pull/790/commits/d2411009c574ff749ac934bd471f2e276b84be6c

cc @hamelsmu @jph00