### PR TITLE
fix typo in migrating nb

### DIFF
--- a/nbs/migrating.ipynb
+++ b/nbs/migrating.ipynb
@@ -57,7 +57,7 @@
     "\n",
     "To automatically upgrade your directives to the new format, run in the root of your repo:\n",
     "\n",
-    "    nbdev_migrate_directives\n",
+    "    nbdev_migrate\n",
     "\n",
     "You should now test that you can export your module by running:\n",
     "\n",


### PR DESCRIPTION
In the migrating notebook, the instruction had a typo, `nbdev_migrate_directives` was changed to `nbdev_migrate`