### PR TITLE
nbdev commands fail when `doc_path` contains whitespace

### DIFF
--- a/nbdev/cli.py
+++ b/nbdev/cli.py
@@ -320,7 +320,7 @@ def _render_readme(path):
         yml_path.rename(path/'sidebar.yml.bak')
         moved=True
     try:
-        _sprun(f'cd {path} && quarto render {idx_path} -o README.md -t gfm --no-execute')
+        _sprun(f'cd "{path}" && quarto render "{idx_path}" -o README.md -t gfm --no-execute')
     finally:
         if moved: (path/'sidebar.yml.bak').rename(yml_path)
 
@@ -355,8 +355,8 @@ def nbdev_quarto(
     files = nbdev_sidebar.__wrapped__(path, symlinks=symlinks, file_re=file_re, folder_re=folder_re,
                             skip_file_glob=skip_file_glob, skip_file_re=skip_file_re, returnit=True)
     shutil.rmtree(doc_path, ignore_errors=True)
-    if preview: os.system(f'cd {path} && quarto preview --no-execute')
-    else: _sprun(f'cd {path} && quarto render --no-execute')
+    if preview: os.system(f'cd "{path}" && quarto preview --no-execute')
+    else: _sprun(f'cd "{path}" && quarto render --no-execute')
     if not preview:
         nbdev_readme.__wrapped__(path, doc_path)
         if tmp_doc_path.parent != cfg_path: # move docs folder to root of repo if it doesn't exist there

--- a/nbs/10_cli.ipynb
+++ b/nbs/10_cli.ipynb
@@ -551,7 +551,7 @@
     "        yml_path.rename(path/'sidebar.yml.bak')\n",
     "        moved=True\n",
     "    try:\n",
-    "        _sprun(f'cd \"{path}\" && quarto render {idx_path} -o README.md -t gfm --no-execute')\n",
+    "        _sprun(f'cd \"{path}\" && quarto render \"{idx_path}\" -o README.md -t gfm --no-execute')\n",
     "    finally:\n",
     "        if moved: (path/'sidebar.yml.bak').rename(yml_path)"
    ]

--- a/nbs/10_cli.ipynb
+++ b/nbs/10_cli.ipynb
@@ -551,7 +551,7 @@
     "        yml_path.rename(path/'sidebar.yml.bak')\n",
     "        moved=True\n",
     "    try:\n",
-    "        _sprun(f'cd {path} && quarto render {idx_path} -o README.md -t gfm --no-execute')\n",
+    "        _sprun(f'cd \"{path}\" && quarto render {idx_path} -o README.md -t gfm --no-execute')\n",
     "    finally:\n",
     "        if moved: (path/'sidebar.yml.bak').rename(yml_path)"
    ]
@@ -602,8 +602,8 @@
     "    files = nbdev_sidebar.__wrapped__(path, symlinks=symlinks, file_re=file_re, folder_re=folder_re,\n",
     "                            skip_file_glob=skip_file_glob, skip_file_re=skip_file_re, returnit=True)\n",
     "    shutil.rmtree(doc_path, ignore_errors=True)\n",
-    "    if preview: os.system(f'cd {path} && quarto preview --no-execute')\n",
-    "    else: _sprun(f'cd {path} && quarto render --no-execute')\n",
+    "    if preview: os.system(f'cd \"{path}\" && quarto preview --no-execute')\n",
+    "    else: _sprun(f'cd \"{path}\" && quarto render --no-execute')\n",
     "    if not preview:\n",
     "        nbdev_readme.__wrapped__(path, doc_path)\n",
     "        if tmp_doc_path.parent != cfg_path: # move docs folder to root of repo if it doesn't exist there\n",


### PR DESCRIPTION
If `doc_path` contains a white space, `nbdev_quarto` crashed as there were no quotes around in the `cd` command.
The same for `nbs_path` and `_render_readme`.

According to the contributing guide every PR should include a test. However, the change in minimal and properly adding a test would require some effort to properly test that the library works with white spaces so I was wondering if it is really needed in this case.