### PR TITLE
Add custom_quarto_yml setting

### DIFF
--- a/nbdev/cli.py
+++ b/nbdev/cli.py
@@ -269,6 +269,8 @@ def refresh_quarto_yml():
     cfg = get_config()
     p = cfg.path('nbs_path')/'_quarto.yml'
     vals = {k:cfg.get(k) for k in ['doc_path', 'title', 'description', 'branch', 'git_url', 'doc_host', 'doc_baseurl']}
+    # Do not build _quarto_yml if custom_quarto_yml is set to True
+    if str2bool(config_key('custom_quarto_yml', default="False", path=False)): return
     if 'title' not in vals: vals['title'] = vals['lib_name']
     yml=_quarto_yml.format(**vals)
     p.write_text(yml)

--- a/nbs/10_cli.ipynb
+++ b/nbs/10_cli.ipynb
@@ -468,6 +468,8 @@
     "    cfg = get_config()\n",
     "    p = cfg.path('nbs_path')/'_quarto.yml'\n",
     "    vals = {k:cfg.get(k) for k in ['doc_path', 'title', 'description', 'branch', 'git_url', 'doc_host', 'doc_baseurl']}\n",
+    "    # Do not build _quarto_yml if custom_quarto_yml is set to True\n",
+    "    if str2bool(config_key('custom_quarto_yml', default=\"False\", path=False)): return\n",
     "    if 'title' not in vals: vals['title'] = vals['lib_name']\n",
     "    yml=_quarto_yml.format(**vals)\n",
     "    p.write_text(yml)"
@@ -662,7 +664,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.12 ('.venv': venv)",
    "language": "python",
    "name": "python3"
   }


### PR DESCRIPTION
Quarto config could be customized by custom.yml but it does not work for all settings.

So I propose to add a nbdev settings to prevent overwriting _quarto.yml.

This option as to be `custom_quarto_yml = False` to keep _quarto.yml.