### PR TITLE
prettify output for `nbdev_test`

### DIFF
--- a/nbdev/test.py
+++ b/nbdev/test.py
@@ -99,7 +99,7 @@ def nbdev_test(
     else: 
         _fence = '='*50
         failed = '\n\t'.join(f.name for p,f in zip(passed,files) if not p)
-        sys.stderr.write(f"\nnbdev Tests Failed On The Following Notebooks:\n{_fence}\n\t{failed}")
+        sys.stderr.write(f"\nnbdev Tests Failed On The Following Notebooks:\n{_fence}\n\t{failed}\n")
         exit(1)
     if timing:
         for i,t in sorted(enumerate(times), key=lambda o:o[1], reverse=True): print(f"{files[i].name}: {int(t)} secs")

--- a/nbs/14_test.ipynb
+++ b/nbs/14_test.ipynb
@@ -206,7 +206,7 @@
     "    else: \n",
     "        _fence = '='*50\n",
     "        failed = '\\n\\t'.join(f.name for p,f in zip(passed,files) if not p)\n",
-    "        sys.stderr.write(f\"\\nnbdev Tests Failed On The Following Notebooks:\\n{_fence}\\n\\t{failed}\")\n",
+    "        sys.stderr.write(f\"\\nnbdev Tests Failed On The Following Notebooks:\\n{_fence}\\n\\t{failed}\\n\")\n",
     "        exit(1)\n",
     "    if timing:\n",
     "        for i,t in sorted(enumerate(times), key=lambda o:o[1], reverse=True): print(f\"{files[i].name}: {int(t)} secs\")"


### PR DESCRIPTION
If tests fail in `nbdev_test`, the console output would look something like this,

![image](https://user-images.githubusercontent.com/31466137/184505245-cef7e86d-16c5-46da-ab9d-24551be36d2a.png)

After the minor fix, it looks like this

![image](https://user-images.githubusercontent.com/31466137/184505255-3640eb99-7f71-408f-9551-e2a7e628f253.png)
