### PR TITLE
Change order of git commands during setup: local first, global second & remove colors

### DIFF
--- a/nbdev/cli.py
+++ b/nbdev/cli.py
@@ -193,13 +193,14 @@ https://nbdev.fast.ai/cli.html#Using-nbdev_new-with-private-repos
 # %% ../nbs/10_cli.ipynb 20
 def _fetch_from_git(raise_err=False):
     "Get information for settings.ini from the user."
-    res = {}
+    res={}
     try:
         url = run('git config --get remote.origin.url')
-        res['author'] = run('git config --get user.name').strip()
-        res['author_email'] = run('git config --get user.email').strip()
         res['user'],res['repo'] = repo_details(url)
-        res['branch'],res['keywords'],res['description'] = _get_info(owner=res['user'], repo=res['repo'])
+        res['branch'],res['keywords'],desc = _get_info(owner=res['user'], repo=res['repo'])
+        if desc: res['description'] = desc
+        res['author'] = run('git config --get user.name').strip() # below two lines attempt to pull from global user config
+        res['author_email'] = run('git config --get user.email').strip()
     except OSError as e:
         if raise_err: raise(e)
     else: res['lib_name'] = res['repo'].replace('-','_')
@@ -214,10 +215,10 @@ def prompt_user(cfg, inferred):
         inf = inferred.get(k,None)
         msg = S.light_blue(k) + ' = '
         if v is None:
-            if inf is None: res[k] = input(S.dark_gray(f'# Please enter a value for {k}\n')+msg)
+            if inf is None: res[k] = input(f'# Please enter a value for {k}\n'+msg)
             else:
                 res[k] = inf
-                print(msg+res[k]+S.dark_gray(' # Automatically inferred from git'))
+                print(msg+res[k]+' # Automatically inferred from git')
         else: print(msg+str(v))
     return res
 

--- a/nbs/10_cli.ipynb
+++ b/nbs/10_cli.ipynb
@@ -365,13 +365,14 @@
     "#|export\n",
     "def _fetch_from_git(raise_err=False):\n",
     "    \"Get information for settings.ini from the user.\"\n",
-    "    res = {}\n",
+    "    res={}\n",
     "    try:\n",
     "        url = run('git config --get remote.origin.url')\n",
-    "        res['author'] = run('git config --get user.name').strip()\n",
-    "        res['author_email'] = run('git config --get user.email').strip()\n",
     "        res['user'],res['repo'] = repo_details(url)\n",
-    "        res['branch'],res['keywords'],res['description'] = _get_info(owner=res['user'], repo=res['repo'])\n",
+    "        res['branch'],res['keywords'],desc = _get_info(owner=res['user'], repo=res['repo'])\n",
+    "        if desc: res['description'] = desc\n",
+    "        res['author'] = run('git config --get user.name').strip() # below two lines attempt to pull from global user config\n",
+    "        res['author_email'] = run('git config --get user.email').strip()\n",
     "    except OSError as e:\n",
     "        if raise_err: raise(e)\n",
     "    else: res['lib_name'] = res['repo'].replace('-','_')\n",
@@ -405,10 +406,10 @@
     "        inf = inferred.get(k,None)\n",
     "        msg = S.light_blue(k) + ' = '\n",
     "        if v is None:\n",
-    "            if inf is None: res[k] = input(S.dark_gray(f'# Please enter a value for {k}\\n')+msg)\n",
+    "            if inf is None: res[k] = input(f'# Please enter a value for {k}\\n'+msg)\n",
     "            else:\n",
     "                res[k] = inf\n",
-    "                print(msg+res[k]+S.dark_gray(' # Automatically inferred from git'))\n",
+    "                print(msg+res[k]+' # Automatically inferred from git')\n",
     "        else: print(msg+str(v))\n",
     "    return res"
    ]
@@ -662,7 +663,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.12 ('.venv': venv)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }


### PR DESCRIPTION
This fixes #846 , by changing the order in which the git commands run, such that the local repository is inspected first and the global user's gitconfig is inspected last.  That way, if this fails, we still have _some_ information we can infer on behalf of the user.  

Furthermore, this removes colors as it made the text invisible for me.

cc: @jph00 @seeM 