### PR TITLE
`show_doc` treats functions decorated with `lru_cache` as classes

### DIFF
--- a/nbdev/showdoc.py
+++ b/nbdev/showdoc.py
@@ -117,7 +117,7 @@ class ShowDocRenderer:
         "Show documentation for `sym`"
         store_attr()
         self.nm = name or qual_name(sym)
-        self.isfunc = inspect.isfunction(sym)
+        self.isfunc = inspect.isfunction(sym) or isinstance(sym, functools._lru_cache_wrapper)
         self.isprop = isinstance_str(sym, 'property')
         if self.isprop: self.sig = None
         else:

--- a/nbs/08_showdoc.ipynb
+++ b/nbs/08_showdoc.ipynb
@@ -515,7 +515,7 @@
     "        \"Show documentation for `sym`\"\n",
     "        store_attr()\n",
     "        self.nm = name or qual_name(sym)\n",
-    "        self.isfunc = inspect.isfunction(sym)\n",
+    "        self.isfunc = inspect.isfunction(sym) or isinstance(sym, functools._lru_cache_wrapper)\n",
     "        self.isprop = isinstance_str(sym, 'property')\n",
     "        if self.isprop: self.sig = None\n",
     "        else:\n",


### PR DESCRIPTION
@hamelsmu @jph00, not sure if this is a good solution?