### PR TITLE
Fix test settings file name

### DIFF
--- a/nbs/01_config.ipynb
+++ b/nbs/01_config.ipynb
@@ -778,7 +778,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cfg = get_config('test_settings.ini', '../tests')\n",
+    "cfg = get_config('settings.ini', '../tests')\n",
     "test_eq(cfg.lib_path, 'nbdev')\n",
     "test_eq(cfg.nbs_path, '.')"
    ]


### PR DESCRIPTION
`test_settings.ini` does not exist