### PR TITLE
Fix broken link in tutorial

### DIFF
--- a/nbs/01_Tutorials/01_tutorial.ipynb
+++ b/nbs/01_Tutorials/01_tutorial.ipynb
@@ -185,7 +185,7 @@
     "nbdev_install_quarto\n",
     "```\n",
     "\n",
-    "Your password may be requested at this point. Since nbdev is open source, you can read [the source code](https://github.com/fastai/nbdev/blob/master/nbdev/shortcuts.py#L33) of this command to verify that it isn't doing anything malicious. Or, if you prefer, you may instead follow [Quarto's official installation instructions](https://quarto.org/docs/get-started/)."
+    "Your password may be requested at this point. Since nbdev is open source, you can read [the source code](https://github.com/fastai/nbdev/blob/master/nbdev/quarto.py#L39) of this command to verify that it isn't doing anything malicious. Or, if you prefer, you may instead follow [Quarto's official installation instructions](https://quarto.org/docs/get-started/)."
    ]
   },
   {


### PR DESCRIPTION
The link to the quarto installer in [the tutorial](https://nbdev.fast.ai/01_Tutorials/tutorial.html#install-quarto) is broken. This PR updates the link to where the quarto installer code currently resides.