### PR TITLE
add `printit` arg to `nbdev_filter` so it can be called with `fname` and still print to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ practices because tests and documentation are first class.
 - **Publish packages to PyPI and conda** as well as tools to simplify
   package releases. Python best practices are automatically followed,
   for example, only exported objects are included in `__all__`
-- **Two-way sync between notebooks and plaintext** allowing you to use
-  your IDE for code navigation or quick edits
+- **Two-way sync between notebooks and plaintext source code** allowing
+  you to use your IDE for code navigation or quick edits
 - **Tests** written as ordinary notebook cells are run in parallel with
   a single command
 - **Continuous integration** out-of-the-box with [GitHub
@@ -71,16 +71,9 @@ that you use for both Jupyter and your project.
 
 ## How to use nbdev
 
-The best way to learn how to use nbdev is to complete one of these
-tutorials (we suggest replicating each step to solidify your
-understanding):
-
-- [Written walkthrough](01_Tutorials/01_tutorial.ipynb)
-- [Video walkthrough](https://www.youtube.com/watch?v=l7zS8Ld4_iA).
-
-Here is the video walkthrough for convenience (to view full screen,
-click the little square in the bottom right of the video; to view in a
-separate Youtube window, click the Youtube logo):
+The best way to learn how to use nbdev is to complete either the
+[written walkthrough](01_Tutorials/01_tutorial.ipynb) or video
+walkthrough:
 
 <div style="text-align: center">
 
@@ -95,10 +88,10 @@ style="border-radius: 10px" width="560" height="315" /></a>
 
 </div>
 
-There’s a [shortened version of the
-walkthrough](https://youtu.be/67FdzLSt4aA) available with coding
-sections sped up using the `unsilence` Python library – it’s 27 minutes
-faster, but a bit harder to follow.
+Alternatively, there’s a [shortened version of the video
+walkthrough](https://youtu.be/67FdzLSt4aA) with coding sections sped up
+using the `unsilence` Python library – it’s 27 minutes faster, but a bit
+harder to follow.
 
 You can also run `nbdev_help` from the terminal to see the full list of
 available commands:

--- a/nbdev/cli.py
+++ b/nbdev/cli.py
@@ -16,7 +16,7 @@ from .frontmatter import FrontmatterProc
 from execnb.nbio import *
 from fastcore.meta import *
 from fastcore.utils import *
-from fastcore.script import call_parse
+from fastcore.script import *
 from fastcore.style import S
 from fastcore.shutil import rmtree,move
 
@@ -50,14 +50,14 @@ class FilterDefaults:
 def nbdev_filter(
     nb_txt:str=None,  # Notebook text (uses stdin if not provided)
     fname:str=None,  # Notebook to read (uses `nb_txt` if not provided)
+    printit:bool_arg=True, # Print to stdout?
 ):
     "A notebook filter for Quarto"
     os.environ["IN_TEST"] = "1"
     try: filt = get_config().get('exporter', FilterDefaults)()
     except FileNotFoundError: filt = FilterDefaults()
-    printit = False
-    if fname: nb_txt = Path(fname).read_text()
-    elif not nb_txt: nb_txt,printit = sys.stdin.read(),True
+    if fname:        nb_txt = Path(fname).read_text()
+    elif not nb_txt: nb_txt = sys.stdin.read()
     nb = dict2nb(loads(nb_txt))
     if printit:
         with open(os.devnull, 'w') as dn:

--- a/nbs/12_cli.ipynb
+++ b/nbs/12_cli.ipynb
@@ -33,7 +33,7 @@
     "from execnb.nbio import *\n",
     "from fastcore.meta import *\n",
     "from fastcore.utils import *\n",
-    "from fastcore.script import call_parse\n",
+    "from fastcore.script import *\n",
     "from fastcore.style import S\n",
     "from fastcore.shutil import rmtree,move\n",
     "\n",
@@ -109,14 +109,14 @@
     "def nbdev_filter(\n",
     "    nb_txt:str=None,  # Notebook text (uses stdin if not provided)\n",
     "    fname:str=None,  # Notebook to read (uses `nb_txt` if not provided)\n",
+    "    printit:bool_arg=True, # Print to stdout?\n",
     "):\n",
     "    \"A notebook filter for Quarto\"\n",
     "    os.environ[\"IN_TEST\"] = \"1\"\n",
     "    try: filt = get_config().get('exporter', FilterDefaults)()\n",
     "    except FileNotFoundError: filt = FilterDefaults()\n",
-    "    printit = False\n",
-    "    if fname: nb_txt = Path(fname).read_text()\n",
-    "    elif not nb_txt: nb_txt,printit = sys.stdin.read(),True\n",
+    "    if fname:        nb_txt = Path(fname).read_text()\n",
+    "    elif not nb_txt: nb_txt = sys.stdin.read()\n",
     "    nb = dict2nb(loads(nb_txt))\n",
     "    if printit:\n",
     "        with open(os.devnull, 'w') as dn:\n",
@@ -136,7 +136,8 @@
    "outputs": [],
    "source": [
     "#|hide\n",
-    "# print(nbdev_filter(fname='/Users/jhoward/git/nbdev/nbs/06_merge.ipynb'))"
+    "# res = nbdev_filter(fname=get_config().path('nbs_path')/'06_merge.ipynb', printit=False)\n",
+    "# print(res)"
    ]
   },
   {
@@ -269,7 +270,7 @@
       "\u001b[1m\u001b[94mnbdev_install_quarto\u001b[0m            Install latest Quarto on macOS or Linux, prints instructions for Windows\n",
       "\u001b[1m\u001b[94mnbdev_merge\u001b[0m                     Git merge driver for notebooks\n",
       "\u001b[1m\u001b[94mnbdev_migrate\u001b[0m                   Convert all directives and callouts in `fname` from v1 to v2\n",
-      "\u001b[1m\u001b[94mnbdev_new\u001b[0m                       Create a new project.\n",
+      "\u001b[1m\u001b[94mnbdev_new\u001b[0m                       Create an nbdev project.\n",
       "\u001b[1m\u001b[94mnbdev_prepare\u001b[0m                   Export, test, and clean notebooks, and render README if needed\n",
       "\u001b[1m\u001b[94mnbdev_preview\u001b[0m                   Preview docs locally\n",
       "\u001b[1m\u001b[94mnbdev_pypi\u001b[0m                      Create and upload Python package to PyPI\n",


### PR DESCRIPTION
Currently, if you call `nbdev_filter --fname foo` from the command-line it will print to stderr because `nbdev_filter` returns the string, and the `nbdev_filter` binary created by setuptools calls `sys.exit(nbdev_filter(...))` which prints to stderr. This is a minor inconvenience when wanting to do something like `nbdev_filter --fname foo | grep output-file` to test its behaviour. cc @hamelsmu @jph00 

The README change is because I forgot to do `nbdev_prepare` on my last PR