### PR TITLE
`nbdev_test` docs deprecation fix.

### DIFF
--- a/nbs/11_test.ipynb
+++ b/nbs/11_test.ipynb
@@ -4,11 +4,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b2022982-581f-4b0c-87cc-5a0f977da3c9",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#|default_exp test"
@@ -18,11 +14,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ac1573c0-bcfc-4912-823d-508d75bf79d9",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#|export\n",
@@ -47,11 +39,7 @@
   {
    "cell_type": "markdown",
    "id": "2084506e-4393-41eb-8057-9406e78e4079",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "# test\n",
     "> Run unit tests on notebooks in parallel"
@@ -61,11 +49,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3f4fa1ad",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#|export\n",
@@ -107,11 +91,7 @@
   {
    "cell_type": "markdown",
    "id": "9dc26b80-6e4e-4a16-bcde-dd4d156289e5",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "`test_nb` can test a notebook, and skip over certain flags:"
    ]
@@ -120,11 +100,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e0cf84ef-bce4-4531-80df-7a4e514a7ffc",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -147,11 +123,7 @@
   {
    "cell_type": "markdown",
    "id": "46117f38",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "In that notebook the cell flagged *notest* raises an exception, which will be returned as a `bool`:"
    ]
@@ -160,11 +132,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f521b5ef",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "_nb = Path('..//tests/directives.ipynb')\n",
@@ -176,11 +144,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d8bf1f1b-935d-4b69-ba96-827c5d7213f0",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#|export\n",
@@ -195,11 +159,7 @@
   {
    "cell_type": "markdown",
    "id": "77ef30c3-38ee-4c77-93df-c1ae4f959eb1",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Sometimes you may wish to override one or more of the skip_flags, in which case you can use the argument `force_flags` which will remove the appropriate tag(s) from `skip_flags`.  This is useful because `skip_flags` are meant to be set in the `tst_flags` field of `settings.ini`, whereas `force_flags` are usually passed in by the user."
    ]
@@ -208,11 +168,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f8cc6a61-a48e-4ab1-89a9-18316ca795d6",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#|export\n",
@@ -255,11 +211,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3cb85960",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#|eval:false\n",
@@ -269,11 +221,7 @@
   {
    "cell_type": "markdown",
    "id": "f0aec103-88e0-41bf-98d0-ea7019ca8680",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "You can even run `nbdev_test` in non nbdev projects, for example, you can test an individual notebook like so:\n",
     "\n",
@@ -291,11 +239,7 @@
   {
    "cell_type": "markdown",
    "id": "8ee3f4db",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## Eval -"
    ]
@@ -304,11 +248,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "267a32f1-8884-497e-a1af-dd38c80d8873",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#|hide\n",
@@ -319,11 +259,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "86f62c6e",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }

--- a/nbs/11_test.ipynb
+++ b/nbs/11_test.ipynb
@@ -4,7 +4,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b2022982-581f-4b0c-87cc-5a0f977da3c9",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "#|default_exp test"
@@ -14,7 +18,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ac1573c0-bcfc-4912-823d-508d75bf79d9",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "#|export\n",
@@ -39,7 +47,11 @@
   {
    "cell_type": "markdown",
    "id": "2084506e-4393-41eb-8057-9406e78e4079",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# test\n",
     "> Run unit tests on notebooks in parallel"
@@ -49,7 +61,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3f4fa1ad",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "#|export\n",
@@ -91,7 +107,11 @@
   {
    "cell_type": "markdown",
    "id": "9dc26b80-6e4e-4a16-bcde-dd4d156289e5",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "`test_nb` can test a notebook, and skip over certain flags:"
    ]
@@ -100,7 +120,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e0cf84ef-bce4-4531-80df-7a4e514a7ffc",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -123,7 +147,11 @@
   {
    "cell_type": "markdown",
    "id": "46117f38",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "In that notebook the cell flagged *notest* raises an exception, which will be returned as a `bool`:"
    ]
@@ -132,7 +160,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f521b5ef",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "_nb = Path('..//tests/directives.ipynb')\n",
@@ -144,7 +176,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d8bf1f1b-935d-4b69-ba96-827c5d7213f0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "#|export\n",
@@ -159,7 +195,11 @@
   {
    "cell_type": "markdown",
    "id": "77ef30c3-38ee-4c77-93df-c1ae4f959eb1",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Sometimes you may wish to override one or more of the skip_flags, in which case you can use the argument `force_flags` which will remove the appropriate tag(s) from `skip_flags`.  This is useful because `skip_flags` are meant to be set in the `tst_flags` field of `settings.ini`, whereas `force_flags` are usually passed in by the user."
    ]
@@ -168,7 +208,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f8cc6a61-a48e-4ab1-89a9-18316ca795d6",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "#|export\n",
@@ -211,7 +255,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3cb85960",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "#|eval:false\n",
@@ -221,25 +269,33 @@
   {
    "cell_type": "markdown",
    "id": "f0aec103-88e0-41bf-98d0-ea7019ca8680",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "You can even run `nbdev_test` in non nbdev projects, for example, you can test an individual notebook like so:\n",
     "\n",
     "```\n",
-    "nbdev_test --fname ..//tests/minimal.ipynb --do_print\n",
+    "nbdev_test --path ../tests/minimal.ipynb --do_print\n",
     "```\n",
     "\n",
     "Or you can test an entire directory of notebooks filtered for only those that match a regular expression:\n",
     "\n",
     "```\n",
-    "nbdev_test --fname ..//tests --file_re '.*test.ipynb' --do_print\n",
+    "nbdev_test --path ../tests --file_re '.*test.ipynb' --do_print\n",
     "```"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "8ee3f4db",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Eval -"
    ]
@@ -248,7 +304,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "267a32f1-8884-497e-a1af-dd38c80d8873",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "#|hide\n",
@@ -259,7 +319,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "86f62c6e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": []
   }


### PR DESCRIPTION
Replaced the `fname` flag with `path` at `nbdev_test`s' docs since `fname` does not work with that command anymore.