### PR TITLE
Misc docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ that you use for both Jupyter and your project.
 ## How to use nbdev
 
 The best way to learn how to use nbdev is to complete either the
-[written walkthrough](01_Tutorials/01_tutorial.ipynb) or video
-walkthrough:
+[written
+walkthrough](https://nbdev.fast.ai/01_Tutorials/01_tutorial.html) or
+video walkthrough:
 
 <div style="text-align: center">
 

--- a/nbs/01_Tutorials/03_modular_nbdev.ipynb
+++ b/nbs/01_Tutorials/03_modular_nbdev.ipynb
@@ -15,7 +15,7 @@
    "id": "a97e9b2c",
    "metadata": {},
    "source": [
-    "While `nbdev_new` gets you started with everything you need to create a delightful Python package, you can also use each of nbdev's components on their own. You might find this useful if you're porting a large system over to nbdev, or if you'd like to customise the nbdev workflow for your own project. Note that all of the commands below work without a settings.ini file."
+    "While `nbdev_new` gets you started with everything you need to create a delightful Python package, **you can also use each of nbdev's components listed below on their own**. You might find this useful if you're porting a large system over to nbdev, or if you'd like to customise the nbdev workflow for your own project. Note that all of the commands below work without a settings.ini file."
    ]
   },
   {
@@ -92,6 +92,46 @@
     "- `nbdev_merge`\n",
     "- `nbdev_trust`"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b9a56e1",
+   "metadata": {},
+   "source": [
+    "#### [`nbdev.release`](/09_API/release.html): Easy packaging on PyPI, conda, and GitHub"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40810bf2",
+   "metadata": {},
+   "source": [
+    "Check out the `nbdev.release` docs for more. Note that this functionality requires a settings.ini file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22d910d0",
+   "metadata": {},
+   "source": [
+    "#### [`nbdev.quarto`](/09_API/quarto.html): Technical documentation with Quarto"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "368989e9",
+   "metadata": {},
+   "source": [
+    "Check out the `nbdev.quarto` docs for more. Note that this functionality requires a settings.ini file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f021291b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/nbs/02_Explanations/config.ipynb
+++ b/nbs/02_Explanations/config.ipynb
@@ -52,6 +52,7 @@
     }
    ],
    "source": [
+    "#| exec_doc\n",
     "#| echo: false\n",
     "!head ../../settings.ini"
    ]
@@ -117,6 +118,7 @@
     }
    ],
    "source": [
+    "#| exec_doc\n",
     "#| echo: false\n",
     "DocmentTbl(nbdev_create_config)"
    ]

--- a/nbs/getting_started.ipynb
+++ b/nbs/getting_started.ipynb
@@ -85,7 +85,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The best way to learn how to use nbdev is to complete either the [written walkthrough](01_Tutorials/01_tutorial.ipynb) or video walkthrough:"
+    "The best way to learn how to use nbdev is to complete either the [written walkthrough](https://nbdev.fast.ai/01_Tutorials/01_tutorial.html) or video walkthrough:"
    ]
   },
   {

--- a/nbs/styles.css
+++ b/nbs/styles.css
@@ -35,3 +35,14 @@ div.description {
   font-size: 135%;
   opacity: 70%;
 }
+
+/* show_doc signature */
+blockquote > pre {
+  font-size: 14px;
+}
+
+.table {
+  font-size: 16px;
+  /* disable striped tables */
+  --bs-table-striped-bg: var(--bs-table-bg);
+}


### PR DESCRIPTION
- fix #949
- add `nbdev.release` and `nbdev.quarto` to "Modular nbdev" page
- keep config explanation updated with `exec_doc`
- styles
    - smaller signature and table font
    - no striped tables

Before style update:

<img width="760" alt="Screenshot 2022-08-28 at 09 13 40" src="https://user-images.githubusercontent.com/559360/187051411-82f10a81-182b-47f6-9a68-40937194f02d.png">

After:

<img width="760" alt="Screenshot 2022-08-28 at 09 13 47" src="https://user-images.githubusercontent.com/559360/187051413-0816dbe6-48a5-4a8f-be50-3cc2f0ea9dea.png">

cc @hamelsmu @jph00