### PR TITLE
update tutorial "Check out your docs" section re:pages enablement

### DIFF
--- a/nbs/01_Tutorials/01_tutorial.ipynb
+++ b/nbs/01_Tutorials/01_tutorial.ipynb
@@ -464,27 +464,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Docs Workflows\n",
-    "\n",
-    "Whenever you change any of the content in your repo, the following workflows will run to generate a docs site (in this order):\n",
-    "\n",
-    "1. `Deploy to GitHub Pages`: This workflow builds the docs with nbdev.\n",
-    "2. `pages build and deployment`: This is a built-in workflow that GitHub provides that deploys the site to GitHub Pages.  \n",
-    "\n",
-    "Should anything go wrong in your page build, you can always look at the logs of these workflows. Like other workflows, these can be found in the Actions tab of your repo:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "![](images/github-actions-pages.png){fig-align=\"center\" .border .rounded .shadow-sm}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Recap"
    ]
   },

--- a/nbs/01_Tutorials/01_tutorial.ipynb
+++ b/nbs/01_Tutorials/01_tutorial.ipynb
@@ -250,7 +250,7 @@
     "\n",
     "#### Try GitHub's powerful CLI\n",
     "\n",
-    "GitHub's web interface is a great way to get started. As you grow more experienced, you might want to explore the CLI (command line interface). We often prefer to use command line tools for repetitive tasks where we're likely to make mistakes. Having those tasks written as small scripts in your terminal means that you can repeat them with little effort.\n",
+    "GitHub's web interface is a great way to get started. As you grow more experienced, you might want to explore [the GitHub CLI](https://github.com/cli/cli) (command line interface). We often prefer to use command line tools for repetitive tasks where we're likely to make mistakes. Having those tasks written as small scripts in your terminal means that you can repeat them with little effort.\n",
     "\n",
     ":::"
    ]
@@ -432,14 +432,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "nbdev hosts your docs on GitHub Pages---an excellent (and free!) way to host websites."
+    "nbdev hosts your docs on GitHub Pages---an excellent (and free!) way to host websites. nbdev automatically enables GitHub Pages when you create a nbdev-enabled GitHub repo."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can enable it for your repo by clicking on the \"Settings\" tab near the top-right of your repo page, then \"Pages\" on the left, then setting the \"Branch\" to \"gh-pages\", and finally clicking \"Save\"."
+    "By default, your docs should be available at: `https://{user}.github.io/{repo}`. For example, you can view `fastai`'s `nbdev-hello-world` docs at <https://fastai.github.io/nbdev-hello-world>:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](images/nbdev-hello-world-site-initial.png){fig-align=\"center\" .border .rounded .shadow-sm}"
    ]
   },
   {
@@ -448,7 +455,7 @@
    "source": [
     "::: {.callout-note}\n",
     "\n",
-    "nbdev uses GitHub Pages by default because its easily accessible, however you can use any host you like.\n",
+    "nbdev uses GitHub Pages by default because its easily accessible. However, you can use any host you like.  The files for the static site are located in a local `/_docs` directory at the root of your repository after running the command `nbdev_docs` .  This directory is not checked into git and is ignored by `.gitignore`, but you can use these files to deploy to any platform you want.\n",
     "\n",
     ":::"
    ]
@@ -457,21 +464,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It should look similar to this after you click \"Save\":"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "![](images/github-enable-pages.png){.pb-2 fig-align=\"center\" .border .rounded .shadow-sm}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Head back to GitHub Actions and you should see a new workflow run: \"pages build and deployment\". As the name says, this workflow deploys your website contents to GitHub Pages."
+    "#### Docs Workflows\n",
+    "\n",
+    "Whenever you change any of the content in your repo, the following workflows will run to generate a docs site (in this order):\n",
+    "\n",
+    "1. `Deploy to GitHub Pages`: This workflow builds the docs with nbdev.\n",
+    "2. `pages build and deployment`: This is a built-in workflow that GitHub provides that deploys the site to GitHub Pages.  \n",
+    "\n",
+    "Should anything go wrong in your page build, you can always look at the logs of these workflows. Like other workflows, these can be found in the Actions tab of your repo:"
    ]
   },
   {
@@ -479,20 +479,6 @@
    "metadata": {},
    "source": [
     "![](images/github-actions-pages.png){fig-align=\"center\" .border .rounded .shadow-sm}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Wait for the workflow run to complete, then open your website. By default it should be available at: `https://{user}.github.io/{repo}`. For example, you can view `fastai`'s `nbdev-hello-world` docs at <https://fastai.github.io/nbdev-hello-world>."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "![](images/nbdev-hello-world-site-initial.png){fig-align=\"center\" .border .rounded .shadow-sm}"
    ]
   },
   {


### PR DESCRIPTION
Since you do not have to enable pages manually, I updated the tutorial to reflect that:

I will explain the workflows of the docs in a separate explanations section that makes show_doc about docs more generally.

<img width="656" alt="image" src="https://user-images.githubusercontent.com/1483922/187525954-c074d5fb-05c1-4938-8cff-dbd150e75d34.png">


cc: @seeM @jph00 
