### PR TITLE
fix #986 use posix path, so windows workflow works

### DIFF
--- a/nbdev/doclinks.py
+++ b/nbdev/doclinks.py
@@ -46,7 +46,7 @@ def patch_name(o):
 def _get_modidx(pyfile, code_root, nbs_path):
     "Get module symbol index for a Python source file"
     cfg = get_config()
-    rel_name = str(pyfile.resolve().relative_to(code_root))
+    rel_name = pyfile.resolve().relative_to(code_root).as_posix()
     mod_name = '.'.join(rel_name.rpartition('.')[0].split('/'))  # module name created by pyfile
     cells = Path(pyfile).read_text().split("\n# %% ")
 
@@ -60,7 +60,7 @@ def _get_modidx(pyfile, code_root, nbs_path):
             nbpath = nbpath.with_name(re.sub(r'\d+[a-zA-Z0-9]*_', '', nbpath.name.lower()))
             loc = nbpath.relative_to(nbs_path).with_suffix('.html')
 
-            def _stor(nm, tree, pre=''): d[f'{mod_name}{pre}.{nm}'] = f'{loc}#{nm.lower()}',rel_name
+            def _stor(nm, tree, pre=''): d[f'{mod_name}{pre}.{nm}'] = f'{loc.as_posix()}#{nm.lower()}',rel_name
             for tree in ast.parse('\n'.join(rest)).body:
                 if isinstance(tree, _def_types): _stor(patch_name(tree), tree)
                 if isinstance(tree, ast.ClassDef):

--- a/nbdev/maker.py
+++ b/nbdev/maker.py
@@ -67,7 +67,7 @@ class ModuleMaker:
         self.fname = dest/(name.replace('.','/') + ".py")
         if is_new: dest.mkdir(parents=True, exist_ok=True)
         else: assert self.fname.exists(), f"{self.fname} does not exist"
-        self.dest2nb = nb_path.relpath(self.fname.parent)
+        self.dest2nb = nb_path.relpath(self.fname.parent).as_posix()
         self.hdr = f"# %% {self.dest2nb}"
 
 # %% ../nbs/09_API/02_maker.ipynb 18

--- a/nbs/09_API/02_maker.ipynb
+++ b/nbs/09_API/02_maker.ipynb
@@ -206,7 +206,7 @@
     "        self.fname = dest/(name.replace('.','/') + \".py\")\n",
     "        if is_new: dest.mkdir(parents=True, exist_ok=True)\n",
     "        else: assert self.fname.exists(), f\"{self.fname} does not exist\"\n",
-    "        self.dest2nb = nb_path.relpath(self.fname.parent)\n",
+    "        self.dest2nb = nb_path.relpath(self.fname.parent).as_posix()\n",
     "        self.hdr = f\"# %% {self.dest2nb}\""
    ]
   },
@@ -798,7 +798,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.0 64-bit",
    "language": "python",
    "name": "python3"
   }

--- a/nbs/09_API/04b_doclinks.ipynb
+++ b/nbs/09_API/04b_doclinks.ipynb
@@ -133,7 +133,7 @@
     "def _get_modidx(pyfile, code_root, nbs_path):\n",
     "    \"Get module symbol index for a Python source file\"\n",
     "    cfg = get_config()\n",
-    "    rel_name = str(pyfile.resolve().relative_to(code_root))\n",
+    "    rel_name = pyfile.resolve().relative_to(code_root).as_posix()\n",
     "    mod_name = '.'.join(rel_name.rpartition('.')[0].split('/'))  # module name created by pyfile\n",
     "    cells = Path(pyfile).read_text().split(\"\\n# %% \")\n",
     "\n",
@@ -147,7 +147,7 @@
     "            nbpath = nbpath.with_name(re.sub(r'\\d+[a-zA-Z0-9]*_', '', nbpath.name.lower()))\n",
     "            loc = nbpath.relative_to(nbs_path).with_suffix('.html')\n",
     "\n",
-    "            def _stor(nm, tree, pre=''): d[f'{mod_name}{pre}.{nm}'] = f'{loc}#{nm.lower()}',rel_name\n",
+    "            def _stor(nm, tree, pre=''): d[f'{mod_name}{pre}.{nm}'] = f'{loc.as_posix()}#{nm.lower()}',rel_name\n",
     "            for tree in ast.parse('\\n'.join(rest)).body:\n",
     "                if isinstance(tree, _def_types): _stor(patch_name(tree), tree)\n",
     "                if isinstance(tree, ast.ClassDef):\n",
@@ -758,7 +758,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.0 64-bit",
    "language": "python",
    "name": "python3"
   }


### PR DESCRIPTION
Based on Jeremy's feedback on [#986](https://github.com/fastai/nbdev/issues/986), I've spend today trying to fix it.

**Problem**
The problem was that windows gave windows path outputs, which makes the github actions workflow break (which uses ubuntu-latest and therefore outputs a different path).

**Change**
I've had to add as_posix() to 2 modules:
doclinks (1 time) and maker (2 times)

**Open issue**
My PR has another change, namely "display_name": "Python 3.10.0 64-bit", It's due to kernelspec being allowed als nb metadata_keys in clean_nb:
```
    "Clean `nb` from superfluous metadata"
    metadata_keys = {"kernelspec", "jekyll", "jupytext", "doc"}
```
Kernelspec could be removed, but I didn't dare, maybe you've left it in for a reason

**Final note**
Now I've had to jump through some hoops since on windows nbdev_export has some unicode problem with the sign for apl ⍝, which made the whole thing fail. Changed it temporarily to be able to run export and discarded this change.
And this is my first contribution to open-source software, I really hope I'm doing things right...
Thanks Jeremy and Hamel for the great software, love fastpages as well.
