### PR TITLE
.get instead of acessing attr

### DIFF
--- a/nbdev/clean.py
+++ b/nbdev/clean.py
@@ -143,7 +143,7 @@ def clean_jupyter(path, model, **kwargs):
     "Clean Jupyter `model` pre save to `path`"
     if not (model['type']=='notebook' and model['content']['nbformat']==4): return
     get_config.cache_clear() # Allow config changes without restarting Jupyter
-    jupyter_hooks = get_config(path=path).jupyter_hooks
+    jupyter_hooks = get_config(path=path).get('jupyter_hooks')
     if jupyter_hooks: _nbdev_clean(model['content'], path=path)
 
 # %% ../nbs/api/clean.ipynb 33

--- a/nbs/api/clean.ipynb
+++ b/nbs/api/clean.ipynb
@@ -415,7 +415,7 @@
     "    \"Clean Jupyter `model` pre save to `path`\"\n",
     "    if not (model['type']=='notebook' and model['content']['nbformat']==4): return\n",
     "    get_config.cache_clear() # Allow config changes without restarting Jupyter\n",
-    "    jupyter_hooks = get_config(path=path).jupyter_hooks\n",
+    "    jupyter_hooks = get_config(path=path).get('jupyter_hooks')\n",
     "    if jupyter_hooks: _nbdev_clean(model['content'], path=path)"
    ]
   },


### PR DESCRIPTION
I get the error when I create a new repo and save any notebook

```
[E 2022-09-09 11:37:30.031 ServerApp] Pre-save hook failed on Untitled.ipynb
    Traceback (most recent call last):
      File "/Users/hamel/opt/anaconda3/lib/python3.9/site-packages/jupyter_server/services/contents/manager.py", line 134, in run_pre_save_hook
        self.pre_save_hook(model=model, path=path, contents_manager=self, **kwargs)
      File "/Users/hamel/.jupyter/jupyter_server_config.py", line 4, in nbdev_clean_jupyter
        clean_jupyter(**kwargs)
      File "/Users/hamel/github/nbdev/nbdev/clean.py", line 146, in clean_jupyter
        jupyter_hooks = get_config(path=path).get('jupyter_hooks')
      File "/Users/hamel/github/fastcore/fastcore/foundation.py", line 269, in __getattr__
        def __getattr__(self,k):   return stop(AttributeError(k)) if k=='d' or k not in self.d else self.get(k)
      File "/Users/hamel/github/fastcore/fastcore/basics.py", line 216, in stop
        raise e
    AttributeError: jupyter_hooks
```

On further investigation, it appears that `cfg._apply_defaults` is not applying a default because mysteriously cfg.get('jupyter_hooks') is returning `False`, even though I have no user level configs.  What is even more mysterious is that 

cfg.get('jupyter_hooks') returns `False`
but `cfg.jupyter_hooks` raises an AttributeError

I have no idea where the `False` is coming from either, but that is a separate issue.  

[This is a repo](https://github.com/hamelsmu/nbdev-demo-j) I created this morning and it failed on that