### PR TITLE
`nbdev_new` support for GitHub Enterprise

### DIFF
--- a/nbdev/cli.py
+++ b/nbdev/cli.py
@@ -87,7 +87,7 @@ def nbdev_new(**kwargs):
     path = Path()
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', UserWarning)
-        tag = GhApi(gh_host='https://api.github.com').repos.get_latest_release('fastai', 'nbdev-template').tag_name
+        tag = GhApi(gh_host='https://api.github.com', authenticate=False).repos.get_latest_release('fastai', 'nbdev-template').tag_name
     url = f"https://github.com/fastai/nbdev-template/archive/{tag}.tar.gz"
     extract_tgz(url)
     tmpl_path = path/f'nbdev-template-{tag}'

--- a/nbs/api/cli.ipynb
+++ b/nbs/api/cli.ipynb
@@ -192,7 +192,7 @@
     "    path = Path()\n",
     "    with warnings.catch_warnings():\n",
     "        warnings.simplefilter('ignore', UserWarning)\n",
-    "        tag = GhApi(gh_host='https://api.github.com').repos.get_latest_release('fastai', 'nbdev-template').tag_name\n",
+    "        tag = GhApi(gh_host='https://api.github.com', authenticate=False).repos.get_latest_release('fastai', 'nbdev-template').tag_name\n",
     "    url = f\"https://github.com/fastai/nbdev-template/archive/{tag}.tar.gz\"\n",
     "    extract_tgz(url)\n",
     "    tmpl_path = path/f'nbdev-template-{tag}'\n",

--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ language = English
 custom_sidebar = True
 license = apache2
 status = 2
-requirements = fastcore>=1.5.24 execnb>=0.1.3 astunparse ghapi>=1.0.2 watchdog asttokens
+requirements = fastcore>=1.5.24 execnb>=0.1.3 astunparse ghapi>=1.0.3 watchdog asttokens
 pip_requirements = PyYAML
 conda_requirements = pyyaml
 conda_user = fastai


### PR DESCRIPTION
- Fixes #1038

Note that this requires `ghapi>=1.0.3` for https://github.com/fastai/ghapi/commit/947cab3e5cf7ce2eaad8cacb1eaed658a0cc8806 **which isn't released yet** cc @hamelsmu @jph00.