### PR TITLE
Setting `put_version_in_init ` to make adding `__version__` to `__init__.py` optional

### DIFF
--- a/nbdev/config.py
+++ b/nbdev/config.py
@@ -63,6 +63,7 @@ def _apply_defaults(
     jupyter_hooks=True, # Run Jupyter hooks?
     clean_ids=True, # Remove ids from plaintext reprs?
     custom_quarto_yml=False, # Use a custom _quarto.yml?
+    put_version_in_init=True, # Add the version to the main __init__.py in nbdev_export
 ):
     "Apply default settings where missing in `cfg`."
     if getattr(cfg,'repo',None) is None:
@@ -189,7 +190,7 @@ def _xdg_config_paths(cfg_name=_nbdev_cfg_name):
 
 # %% ../nbs/api/config.ipynb 28
 _types = dict(custom_sidebar=bool, nbs_path=Path, lib_path=Path, doc_path=Path, recursive=bool, 
-    black_formatting=bool, jupyter_hooks=bool, clean_ids=bool, custom_quarto_yml=bool, preview_port=int)
+    black_formatting=bool, jupyter_hooks=bool, clean_ids=bool, custom_quarto_yml=bool, preview_port=int, put_version_in_init=bool)
 
 @functools.lru_cache(maxsize=None)
 def get_config(cfg_name=_nbdev_cfg_name, path=None):
@@ -241,7 +242,8 @@ def add_init(path=None):
         r = Path(r)
         subds = (os.listdir(r/d) for d in ds)
         if _has_py(fs) or any(filter(_has_py, subds)) and not (r/_init).exists(): (r/_init).touch()
-    update_version(path)
+    if get_config().put_version_in_init:
+        update_version(path)
 
 # %% ../nbs/api/config.ipynb 52
 def write_cells(cells, hdr, file, offset=0):

--- a/nbs/api/config.ipynb
+++ b/nbs/api/config.ipynb
@@ -171,6 +171,7 @@
     "    jupyter_hooks=True, # Run Jupyter hooks?\n",
     "    clean_ids=True, # Remove ids from plaintext reprs?\n",
     "    custom_quarto_yml=False, # Use a custom _quarto.yml?\n",
+    "    put_version_in_init=True, # Add the version to the main __init__.py in nbdev_export\n",
     "):\n",
     "    \"Apply default settings where missing in `cfg`.\"\n",
     "    if getattr(cfg,'repo',None) is None:\n",
@@ -452,7 +453,7 @@
    "source": [
     "#|export\n",
     "_types = dict(custom_sidebar=bool, nbs_path=Path, lib_path=Path, doc_path=Path, recursive=bool, \n",
-    "    black_formatting=bool, jupyter_hooks=bool, clean_ids=bool, custom_quarto_yml=bool, preview_port=int)\n",
+    "    black_formatting=bool, jupyter_hooks=bool, clean_ids=bool, custom_quarto_yml=bool, preview_port=int, put_version_in_init=bool)\n",
     "\n",
     "@functools.lru_cache(maxsize=None)\n",
     "def get_config(cfg_name=_nbdev_cfg_name, path=None):\n",
@@ -699,7 +700,8 @@
     "        r = Path(r)\n",
     "        subds = (os.listdir(r/d) for d in ds)\n",
     "        if _has_py(fs) or any(filter(_has_py, subds)) and not (r/_init).exists(): (r/_init).touch()\n",
-    "    update_version(path)"
+    "    if get_config().put_version_in_init:\n",
+    "        update_version(path)"
    ]
   },
   {
@@ -802,7 +804,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.9 64-bit",
    "language": "python",
    "name": "python3"
   }


### PR DESCRIPTION
Addresses #1050

Adds an option `settings.ini` called `put_version_in_init` that defaults to `True` so that

1. When `True`, we set the version in `__init__.py` as we currently do
2. When `False`, we skip setting the version in `__init__.py`