### PR TITLE
fix #1097

### DIFF
--- a/nbdev/doclinks.py
+++ b/nbdev/doclinks.py
@@ -192,7 +192,7 @@ class NbdevLookup:
         strip_libs = L(strip_libs)
         if incl_libs is not None: incl_libs = (L(incl_libs)+strip_libs).unique()
         # Dict from lib name to _nbdev module for incl_libs (defaults to all)
-        self.entries = {o.name: _qual_syms(o.load()) for o in list(pkg_resources.iter_entry_points(group='nbdev'))
+        self.entries = {o.name: _qual_syms(o.resolve()) for o in list(pkg_resources.iter_entry_points(group='nbdev'))
                        if incl_libs is None or o.dist.key in incl_libs}
         py_syms = merge(*L(o['syms'].values() for o in self.entries.values()).concat())
         for m in strip_libs:

--- a/nbs/api/doclinks.ipynb
+++ b/nbs/api/doclinks.ipynb
@@ -465,7 +465,7 @@
     "        strip_libs = L(strip_libs)\n",
     "        if incl_libs is not None: incl_libs = (L(incl_libs)+strip_libs).unique()\n",
     "        # Dict from lib name to _nbdev module for incl_libs (defaults to all)\n",
-    "        self.entries = {o.name: _qual_syms(o.load()) for o in list(pkg_resources.iter_entry_points(group='nbdev'))\n",
+    "        self.entries = {o.name: _qual_syms(o.resolve()) for o in list(pkg_resources.iter_entry_points(group='nbdev'))\n",
     "                       if incl_libs is None or o.dist.key in incl_libs}\n",
     "        py_syms = merge(*L(o['syms'].values() for o in self.entries.values()).concat())\n",
     "        for m in strip_libs:\n",


### PR DESCRIPTION
For example, install `fastai` then uninstall `Pillow` and `show_doc` will error.

> IIUC the error is raised because doclinks uses `EntryPoint.load` ([source](https://github.com/pypa/setuptools/blob/ba3995e5705a22e13bb5d2231ac22c77e4417747/pkg_resources/__init__.py#L2458)) which runs both `EntryPoint.require` (checks that requirements are satisfied) and `EntryPoint.resolve` (imports and returns the module). I think `require` is too strict for our use-case -- I don't think doclinks should care about whether a user's dependencies are met.