### PR TITLE
`black_formatting` setting is ignored

### DIFF
--- a/nbdev/export.py
+++ b/nbdev/export.py
@@ -32,7 +32,7 @@ def black_format(cell, # Cell to format
     "Processor to format code with `black`"
     try: cfg = get_config()
     except FileNotFoundError: return
-    if (str(cfg.get('black_formatting')).lower() != 'true' and not force) or cell.cell_type != 'code': return
+    if (cfg.get('black_formatting') != 1 and not force) or cell.cell_type != 'code': return
     try: import black
     except: raise ImportError("You must install black: `pip install black` if you wish to use black formatting with nbdev")
     else:

--- a/nbdev/export.py
+++ b/nbdev/export.py
@@ -32,7 +32,7 @@ def black_format(cell, # Cell to format
     "Processor to format code with `black`"
     try: cfg = get_config()
     except FileNotFoundError: return
-    if (cfg.get('black_formatting') != 1 and not force) or cell.cell_type != 'code': return
+    if (not cfg.black_formatting and not force) or cell.cell_type != 'code': return
     try: import black
     except: raise ImportError("You must install black: `pip install black` if you wish to use black formatting with nbdev")
     else:

--- a/nbs/api/export.ipynb
+++ b/nbs/api/export.ipynb
@@ -107,7 +107,7 @@
     "    \"Processor to format code with `black`\"\n",
     "    try: cfg = get_config()\n",
     "    except FileNotFoundError: return\n",
-    "    if (str(cfg.get('black_formatting')).lower() != 'true' and not force) or cell.cell_type != 'code': return\n",
+    "    if (cfg.get('black_formatting') != 1 and not force) or cell.cell_type != 'code': return\n",
     "    try: import black\n",
     "    except: raise ImportError(\"You must install black: `pip install black` if you wish to use black formatting with nbdev\")\n",
     "    else:\n",

--- a/nbs/api/export.ipynb
+++ b/nbs/api/export.ipynb
@@ -107,7 +107,7 @@
     "    \"Processor to format code with `black`\"\n",
     "    try: cfg = get_config()\n",
     "    except FileNotFoundError: return\n",
-    "    if (cfg.get('black_formatting') != 1 and not force) or cell.cell_type != 'code': return\n",
+    "    if (not cfg.black_formatting and not force) or cell.cell_type != 'code': return\n",
     "    try: import black\n",
     "    except: raise ImportError(\"You must install black: `pip install black` if you wish to use black formatting with nbdev\")\n",
     "    else:\n",


### PR DESCRIPTION
The `black_formatting` option is now calling `str2bool` from fastcore so it's value when retrieved by `cfg.get('black_formatting')` is either 0 or 1, so the code path that does the black formatting is currently inaccessible. This changes the comparison to check against `1`.