### PR TITLE
fix broken link to vision tutorial

### DIFF
--- a/nbs/tutorials/best_practices.ipynb
+++ b/nbs/tutorials/best_practices.ipynb
@@ -150,7 +150,7 @@
    "source": [
     "Here are a few examples to get you started:\n",
     "\n",
-    "- fastai's documentation makes extensive use of code examples, plots, images, and tables, for example, the [computer vision intro](https://docs.fast.ai/23_tutorial.vision.html)\n",
+    "- fastai's documentation makes extensive use of code examples, plots, images, and tables, for example, the [computer vision intro](https://docs.fast.ai/tutorial.vision.html)\n",
     "- [`nbdev.release`](/api/release.ipynb) opens with a terminal screencast demo in SVG format created with [asciinema](https://asciinema.org/) and [svg-term-cli](https://github.com/marionebl/svg-term-cli)\n",
     "- The [documentation explanation](/explanations/docs.ipynb#overview) describes a complex data pipeline using a [Mermaid diagram](https://quarto.org/docs/authoring/diagrams.html)\n",
     "- The [directives explanation](/explanations/directives.ipynb) showcases all of nbdev's directives with executable examples in call-out cards (and makes great use of emojis too!)\n",
@@ -1455,7 +1455,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.6 ('py310')",
    "language": "python",
    "name": "python3"
   }


### PR DESCRIPTION
fixes #1123 

I don't know how to keep the metadata display name clean for the PR? Is this maybe a feature that `nbdev_clean` needs? I used it but it doesn't "repair" this part.