### PR TITLE
fix duplicated sections in the sidebar

### DIFF
--- a/nbs/_quarto.yml
+++ b/nbs/_quarto.yml
@@ -20,11 +20,11 @@ website:
     contents:
       - auto: "/*.ipynb"
       - section: Tutorials
-        contents: tutorials
+        contents: tutorials/*
       - section: Explanations
-        contents: explanations
+        contents: explanations/*
       - section: API
-        contents: api
+        contents: api/*
   favicon: favicon.png
   navbar:
     background: primary


### PR DESCRIPTION
Tbh I'm not really sure why it works, but it does.

Before:

<img width="230" alt="image" src="https://user-images.githubusercontent.com/559360/196161824-82bfddb6-1531-4087-b05e-b865d41a8d5d.png">

After:

<img width="228" alt="image" src="https://user-images.githubusercontent.com/559360/196161858-c7f4aa5a-a1fc-4098-ad04-0c7dbb3e4e32.png">