### PR TITLE
Let proc not have code

### DIFF
--- a/nbdev/process.py
+++ b/nbdev/process.py
@@ -58,6 +58,7 @@ def _partition_cell(cell, lang):
     if not cell.source: return [],[]
     lines = cell.source.splitlines(True)
     first_code = first_code_ln(lines, lang=lang)
+    if not first_code: return lines,[]
     return lines[:first_code],lines[first_code:]
 
 # %% ../nbs/api/process.ipynb 18
@@ -70,22 +71,22 @@ def extract_directives(cell, remove=True, lang='python'):
         cell['source'] = ''.join([_norm_quarto(o, lang) for o in dirs if _quarto_re(lang).match(o) or _cell_mgc.match(o)] + code)
     return dict(L(_directive(s, lang) for s in dirs).filter())
 
-# %% ../nbs/api/process.ipynb 22
+# %% ../nbs/api/process.ipynb 23
 def opt_set(var, newval):
     "newval if newval else var"
     return newval if newval else var
 
-# %% ../nbs/api/process.ipynb 23
+# %% ../nbs/api/process.ipynb 24
 def instantiate(x, **kwargs):
     "Instantiate `x` if it's a type"
     return x(**kwargs) if isinstance(x,type) else x
 
 def _mk_procs(procs, nb): return L(procs).map(instantiate, nb=nb)
 
-# %% ../nbs/api/process.ipynb 24
+# %% ../nbs/api/process.ipynb 25
 def _is_direc(f): return getattr(f, '__name__', '-')[-1]=='_'
 
-# %% ../nbs/api/process.ipynb 25
+# %% ../nbs/api/process.ipynb 26
 class NBProcessor:
     "Process cells and nbdev comments in a notebook"
     def __init__(self, path=None, procs=None, nb=None, debug=False, rm_directives=True, process=False):
@@ -125,7 +126,7 @@ class NBProcessor:
         "Process all cells with all processors"
         for proc in self.procs: self._proc(proc)
 
-# %% ../nbs/api/process.ipynb 35
+# %% ../nbs/api/process.ipynb 36
 class Processor:
     "Base class for processors"
     def __init__(self, nb): self.nb = nb

--- a/nbs/api/process.ipynb
+++ b/nbs/api/process.ipynb
@@ -253,6 +253,7 @@
     "    if not cell.source: return [],[]\n",
     "    lines = cell.source.splitlines(True)\n",
     "    first_code = first_code_ln(lines, lang=lang)\n",
+    "    if not first_code: return lines,[]\n",
     "    return lines[:first_code],lines[first_code:]"
    ]
   },
@@ -298,6 +299,20 @@
     "#bar\"\"\")\n",
     "test_eq(extract_directives(exp), {'export':['module'], 'hide':[], 'eval:': ['false'], 'foo': ['bar'], 'woo:': ['baz']})\n",
     "test_eq(exp.source, '#|eval: false\\n# |woo: baz\\n1+2\\n#bar')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3949932b-41f8-425b-8a22-d39168650a04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#|hide\n",
+    "exp  = AttrDict(source = \"\"\"\n",
+    "#| layout .panel-tabset group='setup'\"\"\")\n",
+    "test_eq(extract_directives(exp, lang='python', remove=True), {\"layout\": [\".panel-tabset\", \"group='setup'\"]})\n",
+    "test_eq(exp.source, \"\")"
    ]
   },
   {


### PR DESCRIPTION
I'm writing a lazy processing system that let's me write quarto directives without needing `:::`, so rather than doing:

```markdown
::: {.column-margin}
Some column stuff
:::
```
I can do 
```markdown
#| layout .column-margin
Some things
```

And with the current setup if I wanted to do something such as start a panel tabset group that will go for a while, it just needs to contain a markdown cell with the *start* of the groups, so my logic operates such that my entire cell is:

```markdown
#| layout .panel-tabset group='setup' start
```
And then later I have
```markdown
#| layout end
```
With no code.