### PR TITLE
Fix nbdev pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,7 @@
   name: nbdev_clean
   entry: nbdev_clean
   description: "Clean metadata from notebooks to avoid merge conflicts"
-  language: system
+  language: python
   always_run: true
   pass_filenames: false
 

--- a/nbs/tutorials/pre_commit.ipynb
+++ b/nbs/tutorials/pre_commit.ipynb
@@ -43,52 +43,7 @@
    "id": "0c3c7192-892a-4ff9-acb0-a89fe8a2e4bc",
    "metadata": {},
    "source": [
-    "## Install nbdev and pre-commit"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "29cade2a-32ea-4640-8585-ef0448f8b7f3",
-   "metadata": {},
-   "source": [
-    "To get started, install nbdev:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3acdaca2-0fa0-4355-a585-e12174b7a304",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "::: {.panel-tabset}\n",
-      "\n",
-      "#### pip\n",
-      "\n",
-      "```sh\n",
-      "pip install -U nbdev\n",
-      "```\n",
-      "\n",
-      "#### conda\n",
-      "\n",
-      "```sh\n",
-      "conda install -c fastai nbdev\n",
-      "```\n",
-      "\n",
-      "\n",
-      ":::\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "#| echo: false\n",
-    "#| output: asis\n",
-    "print(_install_nbdev())"
+    "## Install pre-commit"
    ]
   },
   {
@@ -96,7 +51,7 @@
    "id": "d161041d-7585-4177-beb2-06d2fb3919e9",
    "metadata": {},
    "source": [
-    "...then install pre-commit (check [their latest instructions](https://pre-commit.com/#install) if you have any difficulty with these commands):\n",
+    "...Install pre-commit (check [their latest instructions](https://pre-commit.com/#install) if you have any difficulty with these commands):\n",
     "\n",
     "::: {.panel-tabset}\n",
     "\n",


### PR DESCRIPTION
By fixing the `language` at the pre-commit hook config, this remove the necessity to manually install `nbdev` with pre-commit. 

Before this fix, when using the pre-commit, we have a duplicated `nbdev` environments, one at the pre-commit files (which should be the one used) and another in your environments (which was what was being used). With this fix, the pre-commit will use the files from pre-commit environment -- which will be cached between multiples repo.

Also, this will possibly fix the `nbdev` hook to work with [pre-commit ci](https://pre-commit.ci/).