### PR TITLE
add filename in error message to migrate utility

### DIFF
--- a/nbdev/migrate.py
+++ b/nbdev/migrate.py
@@ -173,5 +173,7 @@ def nbdev_migrate(
     _skip_re = None if no_skip else '^[_.]'
     if path is None: path = get_config().nbs_path
     for f in globtastic(path, file_re='(.ipynb$)|(.md$)', skip_folder_re=_skip_re, func=Path):
-        if f.name.endswith('.ipynb'): migrate_nb(f)
-        if f.name.endswith('.md'): migrate_md(f)        
+        try:
+            if f.name.endswith('.ipynb'): migrate_nb(f)
+            if f.name.endswith('.md'): migrate_md(f)
+        except Exception as e: raise Exception(f'Error in migrating file: {f}') from e

--- a/nbs/api/migrate.ipynb
+++ b/nbs/api/migrate.ipynb
@@ -1051,8 +1051,10 @@
     "    _skip_re = None if no_skip else '^[_.]'\n",
     "    if path is None: path = get_config().nbs_path\n",
     "    for f in globtastic(path, file_re='(.ipynb$)|(.md$)', skip_folder_re=_skip_re, func=Path):\n",
-    "        if f.name.endswith('.ipynb'): migrate_nb(f)\n",
-    "        if f.name.endswith('.md'): migrate_md(f)        "
+    "        try:\n",
+    "            if f.name.endswith('.ipynb'): migrate_nb(f)\n",
+    "            if f.name.endswith('.md'): migrate_md(f)\n",
+    "        except Exception as e: raise Exception(f'Error in migrating file: {f}') from e"
    ]
   },
   {


### PR DESCRIPTION
closes #1177 

This is what the error message will look like now

```
Traceback (most recent call last):
  File "/Users/hamel/github/nbdev/nbdev/migrate.py", line 178, in nbdev_migrate
    if f.name.endswith('.md'): migrate_md(f)
  File "/Users/hamel/github/nbdev/nbdev/migrate.py", line 162, in migrate_md
    txt = fp_md_fm(path)
  File "/Users/hamel/github/nbdev/nbdev/migrate.py", line 97, in fp_md_fm
    fm = _fp_convert(fm, path)
  File "/Users/hamel/github/nbdev/nbdev/migrate.py", line 78, in _fp_convert
    if k in fm: fm[k] = _rm_quote(fm[k])
  File "/Users/hamel/github/nbdev/nbdev/migrate.py", line 57, in _rm_quote
    title = re.search('''"(.*?)"''', s)
  File "/opt/anaconda3/lib/python3.9/re.py", line 201, in search
    return _compile(pattern, flags).search(string)
TypeError: expected string or bytes-like object

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/anaconda3/bin/nbdev_migrate", line 33, in <module>
    sys.exit(load_entry_point('nbdev', 'console_scripts', 'nbdev_migrate')())
  File "/Users/hamel/github/fastcore/fastcore/script.py", line 119, in _f
    return tfunc(**merge(args, args_from_prog(func, xtra)))
  File "/Users/hamel/github/nbdev/nbdev/migrate.py", line 179, in nbdev_migrate
    except Exception as e: raise Exception(f'Error in migrating file: {f}') from e
Exception: Error in migrating file: posts/2021-12-11-redaction-progress-week-one.md
```