### PR TITLE
nbdev_export now sorts by notebook filename

### DIFF
--- a/nbdev/doclinks.py
+++ b/nbdev/doclinks.py
@@ -100,15 +100,18 @@ def _build_modidx(dest=None, nbs_path=None, skip_exists=False):
 
 # %% ../nbs/api/doclinks.ipynb 20
 @delegates(globtastic)
-def nbglob(path=None, skip_folder_re = '^[_.]', file_glob='*.ipynb', skip_file_re='^[_.]', key='nbs_path', as_path=False, **kwargs):
+def nbglob(path=None, skip_folder_re = '^[_.]', file_glob='*.ipynb', skip_file_re='^[_.]', key='nbs_path', as_path=False, sort_by=None, **kwargs):
     "Find all files in a directory matching an extension given a config key."
     path = Path(path or get_config()[key])
     recursive=get_config().recursive
     res = globtastic(path, file_glob=file_glob, skip_folder_re=skip_folder_re,
                      skip_file_re=skip_file_re, recursive=recursive, **kwargs)
-    return res.map(Path) if as_path else res
+    res = res.map(Path) if as_path else res
+    if sort_by is not None:
+        res.sort(key=sort_by)
+    return res
 
-# %% ../nbs/api/doclinks.ipynb 21
+# %% ../nbs/api/doclinks.ipynb 23
 def nbglob_cli(
     path:str=None, # Path to notebooks
     symlinks:bool=False, # Follow symlinks?
@@ -122,7 +125,7 @@ def nbglob_cli(
     return nbglob(path, symlinks=symlinks, file_glob=file_glob, file_re=file_re, folder_re=folder_re,
                   skip_file_glob=skip_file_glob, skip_file_re=skip_file_re, skip_folder_re=skip_folder_re)
 
-# %% ../nbs/api/doclinks.ipynb 22
+# %% ../nbs/api/doclinks.ipynb 24
 @call_parse
 @delegates(nbglob_cli)
 def nbdev_export(
@@ -130,16 +133,16 @@ def nbdev_export(
     **kwargs):
     "Export notebooks in `path` to Python modules"
     if os.environ.get('IN_TEST',0): return
-    files = nbglob(path=path, **kwargs)
+    files = nbglob(path=path, as_path=True, sort_by=lambda path_str: Path(path_str).name, **kwargs)
     for f in files: nb_export(f)
     add_init(get_config().lib_path)
     _build_modidx()
 
-# %% ../nbs/api/doclinks.ipynb 24
+# %% ../nbs/api/doclinks.ipynb 26
 import importlib,ast
 from functools import lru_cache
 
-# %% ../nbs/api/doclinks.ipynb 25
+# %% ../nbs/api/doclinks.ipynb 27
 def _find_mod(mod):
     mp,_,mr = mod.partition('/')
     spec = importlib.util.find_spec(mp)
@@ -162,7 +165,7 @@ def _get_exps(mod):
 
 def _lineno(sym, fname): return _get_exps(fname).get(sym, None) if fname else None
 
-# %% ../nbs/api/doclinks.ipynb 27
+# %% ../nbs/api/doclinks.ipynb 29
 def _qual_sym(s, settings):
     if not isinstance(s,tuple): return s
     nb,py = s
@@ -177,10 +180,10 @@ def _qual_syms(entries):
     if 'doc_host' not in settings: return entries
     return {'syms': {mod:_qual_mod(d, settings) for mod,d in entries['syms'].items()}, 'settings':settings}
 
-# %% ../nbs/api/doclinks.ipynb 28
+# %% ../nbs/api/doclinks.ipynb 30
 _re_backticks = re.compile(r'`([^`\s]+)`')
 
-# %% ../nbs/api/doclinks.ipynb 29
+# %% ../nbs/api/doclinks.ipynb 31
 @lru_cache(None)
 class NbdevLookup:
     "Mapping from symbol names to docs and source URLs"

--- a/nbs/api/doclinks.ipynb
+++ b/nbs/api/doclinks.ipynb
@@ -306,13 +306,39 @@
    "source": [
     "#|export\n",
     "@delegates(globtastic)\n",
-    "def nbglob(path=None, skip_folder_re = '^[_.]', file_glob='*.ipynb', skip_file_re='^[_.]', key='nbs_path', as_path=False, **kwargs):\n",
+    "def nbglob(path=None, skip_folder_re = '^[_.]', file_glob='*.ipynb', skip_file_re='^[_.]', key='nbs_path', as_path=False, sort_by=None, **kwargs):\n",
     "    \"Find all files in a directory matching an extension given a config key.\"\n",
     "    path = Path(path or get_config()[key])\n",
     "    recursive=get_config().recursive\n",
     "    res = globtastic(path, file_glob=file_glob, skip_folder_re=skip_folder_re,\n",
     "                     skip_file_re=skip_file_re, recursive=recursive, **kwargs)\n",
-    "    return res.map(Path) if as_path else res"
+    "    res = res.map(Path) if as_path else res\n",
+    "    if sort_by is not None:\n",
+    "        res.sort(key=sort_by)\n",
+    "    return res"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`globtastic` uses `glob.glob`, which in turn uses `os.listdir` under the hood. As the [documentation](https://docs.python.org/3/library/os.html#os.listdir) states, the order of results returned by `os.listdir` is arbitrary, hence we need to be able to sort the notebook-paths when needed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import copy\n",
+    "\n",
+    "globtastic_save = copy.copy(globtastic)\n",
+    "\n",
+    "globtastic = lambda *args, **kwargs: ['../../8.ipynb', 'api/3.ipynb', '4.ipynb']\n",
+    "assert nbglob(sort_by=lambda path_str: Path(path_str).name) == ['api/3.ipynb', '4.ipynb', '../../8.ipynb']\n",
+    "\n",
+    "globtastic = globtastic_save"
    ]
   },
   {
@@ -350,7 +376,7 @@
     "    **kwargs):\n",
     "    \"Export notebooks in `path` to Python modules\"\n",
     "    if os.environ.get('IN_TEST',0): return\n",
-    "    files = nbglob(path=path, **kwargs)\n",
+    "    files = nbglob(path=path, as_path=True, sort_by=lambda path_str: Path(path_str).name, **kwargs)\n",
     "    for f in files: nb_export(f)\n",
     "    add_init(get_config().lib_path)\n",
     "    _build_modidx()"
@@ -552,7 +578,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L209){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L210){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.doc\n",
        "\n",
@@ -563,7 +589,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L209){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L210){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.doc\n",
        "\n",
@@ -612,7 +638,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'NoneType' object has no attribute 'startswith'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Input \u001b[0;32mIn [30]\u001b[0m, in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[43mc\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdoc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mnumpy.array\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mstartswith\u001b[49m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mhttp\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m c\u001b[38;5;241m.\u001b[39mdoc(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mNbdevLookup\u001b[39m\u001b[38;5;124m'\u001b[39m)\u001b[38;5;241m.\u001b[39mendswith(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m#nbdevlookup\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m c\u001b[38;5;241m.\u001b[39mdoc(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124marray\u001b[39m\u001b[38;5;124m'\u001b[39m)\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'NoneType' object has no attribute 'startswith'"
+     ]
+    }
+   ],
    "source": [
     "assert c.doc('numpy.array').startswith('http')\n",
     "assert c.doc('NbdevLookup').endswith('#nbdevlookup')\n",
@@ -640,37 +678,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L214){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### NbdevLookup.code\n",
-       "\n",
-       ">      NbdevLookup.code (sym)\n",
-       "\n",
-       "Link to source code for `sym`"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L214){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### NbdevLookup.code\n",
-       "\n",
-       ">      NbdevLookup.code (sym)\n",
-       "\n",
-       "Link to source code for `sym`"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(NbdevLookup.code)"
    ]
@@ -679,18 +687,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'https://github.com/fastai/fastcore/blob/master/fastcore/net.py#LNone'"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "NbdevLookup().code('fastcore.net.urlsend')"
    ]
@@ -699,33 +696,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L231){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### NbdevLookup.linkify\n",
-       "\n",
-       ">      NbdevLookup.linkify (md)"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L231){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### NbdevLookup.linkify\n",
-       "\n",
-       ">      NbdevLookup.linkify (md)"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(NbdevLookup.linkify)"
    ]
@@ -750,22 +721,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This is a link to [`numpy.array`](https://numpy.org/doc/stable/reference/generated/numpy.array.html#numpy.array) and to [`get_config`](https://nbdev.fast.ai/api/config.html#get_config) but not a link to `foobar`.\n",
-      "And not a link to <code>dict2nb</code>.\n",
-      "\n",
-      "    This is not a link to `get_config`\n",
-      "\n",
-      "```\n",
-      "This isn't a link to `get_config` either\n",
-      "```\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#|eval: false\n",
     "print(NbdevLookup('nbdev').linkify(md))"


### PR DESCRIPTION
Fixes the issue described here: 
https://github.com/fastai/nbdev/issues/1190

It matters in which order notebooks are exported, as a notebook with `#| default_exp A` needs to be exported before any notebooks than contain a cell starting with `#| export A`. The order in which the notebooks are exported so far is arbitrary (https://docs.python.org/3/library/os.html#os.listdir).

This PR adds an option to `nbglob` to sort the results by an arbitrary key-function. Then it extends `nbdev_export`s call to `nbglob` by passing a sorting-key-function that sorts by the notebook filenames.

The pipeline linked in the issue above is fixed when using the nbdev fork that is requested to be merged here.