### PR TITLE
nb_export now exports notebooks in ascending-filename-order

### DIFF
--- a/nbdev/doclinks.py
+++ b/nbdev/doclinks.py
@@ -100,15 +100,18 @@ def _build_modidx(dest=None, nbs_path=None, skip_exists=False):
 
 # %% ../nbs/api/doclinks.ipynb 20
 @delegates(globtastic)
-def nbglob(path=None, skip_folder_re = '^[_.]', file_glob='*.ipynb', skip_file_re='^[_.]', key='nbs_path', as_path=False, **kwargs):
+def nbglob(path=None, skip_folder_re = '^[_.]', file_glob='*.ipynb', skip_file_re='^[_.]', key='nbs_path', as_path=False, sort_by=None, **kwargs):
     "Find all files in a directory matching an extension given a config key."
     path = Path(path or get_config()[key])
     recursive=get_config().recursive
     res = globtastic(path, file_glob=file_glob, skip_folder_re=skip_folder_re,
                      skip_file_re=skip_file_re, recursive=recursive, **kwargs)
-    return res.map(Path) if as_path else res
+    res = res.map(Path) if as_path else res
+    if sort_by is not None:
+        res.sort(key=sort_by)
+    return res
 
-# %% ../nbs/api/doclinks.ipynb 21
+# %% ../nbs/api/doclinks.ipynb 23
 def nbglob_cli(
     path:str=None, # Path to notebooks
     symlinks:bool=False, # Follow symlinks?
@@ -122,7 +125,7 @@ def nbglob_cli(
     return nbglob(path, symlinks=symlinks, file_glob=file_glob, file_re=file_re, folder_re=folder_re,
                   skip_file_glob=skip_file_glob, skip_file_re=skip_file_re, skip_folder_re=skip_folder_re)
 
-# %% ../nbs/api/doclinks.ipynb 22
+# %% ../nbs/api/doclinks.ipynb 24
 @call_parse
 @delegates(nbglob_cli)
 def nbdev_export(
@@ -130,16 +133,16 @@ def nbdev_export(
     **kwargs):
     "Export notebooks in `path` to Python modules"
     if os.environ.get('IN_TEST',0): return
-    files = nbglob(path=path, **kwargs)
+    files = nbglob(path=path, as_path=True, sort_by=lambda path_str: Path(path_str).name, **kwargs)
     for f in files: nb_export(f)
     add_init(get_config().lib_path)
     _build_modidx()
 
-# %% ../nbs/api/doclinks.ipynb 24
+# %% ../nbs/api/doclinks.ipynb 26
 import importlib,ast
 from functools import lru_cache
 
-# %% ../nbs/api/doclinks.ipynb 25
+# %% ../nbs/api/doclinks.ipynb 27
 def _find_mod(mod):
     mp,_,mr = mod.partition('/')
     spec = importlib.util.find_spec(mp)
@@ -162,7 +165,7 @@ def _get_exps(mod):
 
 def _lineno(sym, fname): return _get_exps(fname).get(sym, None) if fname else None
 
-# %% ../nbs/api/doclinks.ipynb 27
+# %% ../nbs/api/doclinks.ipynb 29
 def _qual_sym(s, settings):
     if not isinstance(s,tuple): return s
     nb,py = s
@@ -177,10 +180,10 @@ def _qual_syms(entries):
     if 'doc_host' not in settings: return entries
     return {'syms': {mod:_qual_mod(d, settings) for mod,d in entries['syms'].items()}, 'settings':settings}
 
-# %% ../nbs/api/doclinks.ipynb 28
+# %% ../nbs/api/doclinks.ipynb 30
 _re_backticks = re.compile(r'`([^`\s]+)`')
 
-# %% ../nbs/api/doclinks.ipynb 29
+# %% ../nbs/api/doclinks.ipynb 31
 @lru_cache(None)
 class NbdevLookup:
     "Mapping from symbol names to docs and source URLs"

--- a/nbs/api/doclinks.ipynb
+++ b/nbs/api/doclinks.ipynb
@@ -306,13 +306,39 @@
    "source": [
     "#|export\n",
     "@delegates(globtastic)\n",
-    "def nbglob(path=None, skip_folder_re = '^[_.]', file_glob='*.ipynb', skip_file_re='^[_.]', key='nbs_path', as_path=False, **kwargs):\n",
+    "def nbglob(path=None, skip_folder_re = '^[_.]', file_glob='*.ipynb', skip_file_re='^[_.]', key='nbs_path', as_path=False, sort_by=None, **kwargs):\n",
     "    \"Find all files in a directory matching an extension given a config key.\"\n",
     "    path = Path(path or get_config()[key])\n",
     "    recursive=get_config().recursive\n",
     "    res = globtastic(path, file_glob=file_glob, skip_folder_re=skip_folder_re,\n",
     "                     skip_file_re=skip_file_re, recursive=recursive, **kwargs)\n",
-    "    return res.map(Path) if as_path else res"
+    "    res = res.map(Path) if as_path else res\n",
+    "    if sort_by is not None:\n",
+    "        res.sort(key=sort_by)\n",
+    "    return res"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`globtastic` uses `glob.glob`, which in turn uses `os.listdir` under the hood. As the [documentation](https://docs.python.org/3/library/os.html#os.listdir) states, the order of results returned by `os.listdir` is arbitrary, hence we need to be able to sort the notebook-paths when needed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import copy\n",
+    "\n",
+    "globtastic_save = copy.copy(globtastic)\n",
+    "\n",
+    "globtastic = lambda *args, **kwargs: ['../../8.ipynb', 'api/3.ipynb', '4.ipynb']\n",
+    "assert nbglob(sort_by=lambda path_str: Path(path_str).name) == ['api/3.ipynb', '4.ipynb', '../../8.ipynb']\n",
+    "\n",
+    "globtastic = globtastic_save"
    ]
   },
   {
@@ -350,7 +376,7 @@
     "    **kwargs):\n",
     "    \"Export notebooks in `path` to Python modules\"\n",
     "    if os.environ.get('IN_TEST',0): return\n",
-    "    files = nbglob(path=path, **kwargs)\n",
+    "    files = nbglob(path=path, as_path=True, sort_by=lambda path_str: Path(path_str).name, **kwargs)\n",
     "    for f in files: nb_export(f)\n",
     "    add_init(get_config().lib_path)\n",
     "    _build_modidx()"


### PR DESCRIPTION
Fixes the issue described here:
https://github.com/fastai/nbdev/issues/1190

It matters in which order notebooks are exported, as a notebook with #| default_exp A needs to be exported before any notebooks than contain a cell starting with #| export A. The order in which the notebooks are exported so far is arbitrary (https://docs.python.org/3/library/os.html#os.listdir).

This PR adds an option to nbglob to sort the results by an arbitrary key-function. Then it extends nbdev_exports call to nbglob by passing a sorting-key-function that sorts by the notebook filenames.

The pipeline linked in the issue above is fixed when using the nbdev fork that is requested to be merged here.