### PR TITLE
add parameter for name to nb_export

### DIFF
--- a/nbdev/export.py
+++ b/nbdev/export.py
@@ -41,7 +41,7 @@ def black_format(cell, # Cell to format
         except: pass
 
 # %% ../nbs/api/export.ipynb 9
-def nb_export(nbname, lib_path=None, procs=black_format, debug=False, mod_maker=ModuleMaker):
+def nb_export(nbname, lib_path=None, procs=black_format, debug=False, mod_maker=ModuleMaker, name=None):
     "Create module(s) from notebook"
     if lib_path is None: lib_path = get_config().lib_path
     exp = ExportModuleProc()
@@ -49,7 +49,7 @@ def nb_export(nbname, lib_path=None, procs=black_format, debug=False, mod_maker=
     nb.process()
     for mod,cells in exp.modules.items():
         all_cells = exp.in_all[mod]
-        name = getattr(exp, 'default_exp', None) if mod=='#' else mod
+        name = ifnone(name, getattr(exp, 'default_exp', None) if mod=='#' else mod)
         if not name:
             warn(f"Notebook '{nbname}' uses `#|export` without `#|default_exp` cell.\n"
                  "Note nbdev2 no longer supports nbdev1 syntax. Run `nbdev_migrate` to upgrade.\n"

--- a/nbdev/export.py
+++ b/nbdev/export.py
@@ -49,11 +49,11 @@ def nb_export(nbname, lib_path=None, procs=black_format, debug=False, mod_maker=
     nb.process()
     for mod,cells in exp.modules.items():
         all_cells = exp.in_all[mod]
-        name = ifnone(name, getattr(exp, 'default_exp', None) if mod=='#' else mod)
-        if not name:
+        nm = ifnone(name, getattr(exp, 'default_exp', None) if mod=='#' else mod)
+        if not nm:
             warn(f"Notebook '{nbname}' uses `#|export` without `#|default_exp` cell.\n"
                  "Note nbdev2 no longer supports nbdev1 syntax. Run `nbdev_migrate` to upgrade.\n"
                  "See https://nbdev.fast.ai/getting_started.html for more information.")
             return
-        mm = mod_maker(dest=lib_path, name=name, nb_path=nbname, is_new=mod=='#')
+        mm = mod_maker(dest=lib_path, name=nm, nb_path=nbname, is_new=bool(name) or mod=='#')
         mm.make(cells, all_cells, lib_path=lib_path)

--- a/nbs/_quarto.yml
+++ b/nbs/_quarto.yml
@@ -23,8 +23,6 @@ website:
         contents: tutorials/*
       - section: Explanations
         contents: explanations/*
-      - section: Integrations
-        contents: integrations/**/*.ipynb
       - section: API
         contents: api/*
   favicon: favicon.png

--- a/nbs/_quarto.yml
+++ b/nbs/_quarto.yml
@@ -23,6 +23,8 @@ website:
         contents: tutorials/*
       - section: Explanations
         contents: explanations/*
+      - section: Integrations
+        contents: integrations/**/*.ipynb
       - section: API
         contents: api/*
   favicon: favicon.png

--- a/nbs/api/export.ipynb
+++ b/nbs/api/export.ipynb
@@ -185,19 +185,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AssertionError",
-     "evalue": "h_n",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "Input \u001b[0;32mIn [10]\u001b[0m, in \u001b[0;36m<cell line: 7>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      5\u001b[0m _alls \u001b[38;5;241m=\u001b[39m L(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124ma b d e m n o p q\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;241m.\u001b[39msplit())\n\u001b[1;32m      6\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m s \u001b[38;5;129;01min\u001b[39;00m _alls\u001b[38;5;241m.\u001b[39mmap(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{}\u001b[39;00m\u001b[38;5;124m_y\u001b[39m\u001b[38;5;124m\"\u001b[39m): \u001b[38;5;28;01massert\u001b[39;00m s \u001b[38;5;129;01min\u001b[39;00m g, s\n\u001b[0;32m----> 7\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m s \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mc_y_nall _f_y_nall g_n h_n i_n j_n k_n l_n\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;241m.\u001b[39msplit(): \u001b[38;5;28;01massert\u001b[39;00m s \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m g, s\n\u001b[1;32m      8\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m s \u001b[38;5;129;01min\u001b[39;00m _alls\u001b[38;5;241m.\u001b[39mmap(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{}\u001b[39;00m\u001b[38;5;124m_y\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m+\u001b[39m [\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mc_y_nall\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_f_y_nall\u001b[39m\u001b[38;5;124m\"\u001b[39m]: \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(g[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mtmp\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;241m.\u001b[39meverything,s), s\n",
-      "\u001b[0;31mAssertionError\u001b[0m: h_n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#|eval: false\n",
     "nb_export(everything_fn, 'tmp')\n",

--- a/nbs/api/export.ipynb
+++ b/nbs/api/export.ipynb
@@ -142,13 +142,13 @@
     "    nb.process()\n",
     "    for mod,cells in exp.modules.items():\n",
     "        all_cells = exp.in_all[mod]\n",
-    "        name = ifnone(name, getattr(exp, 'default_exp', None) if mod=='#' else mod)\n",
-    "        if not name:\n",
+    "        nm = ifnone(name, getattr(exp, 'default_exp', None) if mod=='#' else mod)\n",
+    "        if not nm:\n",
     "            warn(f\"Notebook '{nbname}' uses `#|export` without `#|default_exp` cell.\\n\"\n",
     "                 \"Note nbdev2 no longer supports nbdev1 syntax. Run `nbdev_migrate` to upgrade.\\n\"\n",
     "                 \"See https://nbdev.fast.ai/getting_started.html for more information.\")\n",
     "            return\n",
-    "        mm = mod_maker(dest=lib_path, name=name, nb_path=nbname, is_new=mod=='#')\n",
+    "        mm = mod_maker(dest=lib_path, name=nm, nb_path=nbname, is_new=bool(name) or mod=='#')\n",
     "        mm.make(cells, all_cells, lib_path=lib_path)"
    ]
   },

--- a/nbs/api/export.ipynb
+++ b/nbs/api/export.ipynb
@@ -134,7 +134,7 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def nb_export(nbname, lib_path=None, procs=black_format, debug=False, mod_maker=ModuleMaker):\n",
+    "def nb_export(nbname, lib_path=None, procs=black_format, debug=False, mod_maker=ModuleMaker, name=None):\n",
     "    \"Create module(s) from notebook\"\n",
     "    if lib_path is None: lib_path = get_config().lib_path\n",
     "    exp = ExportModuleProc()\n",
@@ -142,7 +142,7 @@
     "    nb.process()\n",
     "    for mod,cells in exp.modules.items():\n",
     "        all_cells = exp.in_all[mod]\n",
-    "        name = getattr(exp, 'default_exp', None) if mod=='#' else mod\n",
+    "        name = ifnone(name, getattr(exp, 'default_exp', None) if mod=='#' else mod)\n",
     "        if not name:\n",
     "            warn(f\"Notebook '{nbname}' uses `#|export` without `#|default_exp` cell.\\n\"\n",
     "                 \"Note nbdev2 no longer supports nbdev1 syntax. Run `nbdev_migrate` to upgrade.\\n\"\n",
@@ -185,7 +185,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "h_n",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Input \u001b[0;32mIn [10]\u001b[0m, in \u001b[0;36m<cell line: 7>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      5\u001b[0m _alls \u001b[38;5;241m=\u001b[39m L(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124ma b d e m n o p q\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;241m.\u001b[39msplit())\n\u001b[1;32m      6\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m s \u001b[38;5;129;01min\u001b[39;00m _alls\u001b[38;5;241m.\u001b[39mmap(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{}\u001b[39;00m\u001b[38;5;124m_y\u001b[39m\u001b[38;5;124m\"\u001b[39m): \u001b[38;5;28;01massert\u001b[39;00m s \u001b[38;5;129;01min\u001b[39;00m g, s\n\u001b[0;32m----> 7\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m s \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mc_y_nall _f_y_nall g_n h_n i_n j_n k_n l_n\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;241m.\u001b[39msplit(): \u001b[38;5;28;01massert\u001b[39;00m s \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m g, s\n\u001b[1;32m      8\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m s \u001b[38;5;129;01min\u001b[39;00m _alls\u001b[38;5;241m.\u001b[39mmap(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{}\u001b[39;00m\u001b[38;5;124m_y\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m+\u001b[39m [\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mc_y_nall\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_f_y_nall\u001b[39m\u001b[38;5;124m\"\u001b[39m]: \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(g[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mtmp\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;241m.\u001b[39meverything,s), s\n",
+      "\u001b[0;31mAssertionError\u001b[0m: h_n"
+     ]
+    }
+   ],
    "source": [
     "#|eval: false\n",
     "nb_export(everything_fn, 'tmp')\n",


### PR DESCRIPTION
This allows me to avoid having `#|default_exp` in singleton notebooks where I just want to export to a script.  This is helpful for people using nbdev for one-off purposes they don't have to worry about what `#|default_exp` means and they can just call nb_export() with an argument if they want

I'm using these changes in #1205 