### PR TITLE
add conda install doc to end-to-end tutorial

### DIFF
--- a/nbs/tutorials/tutorial.ipynb
+++ b/nbs/tutorials/tutorial.ipynb
@@ -1375,9 +1375,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Upload to conda\n",
+    "\n",
+    "Similar to `pip install` support, we have provided an anaconda compliant installer to upload your project to [anaconda](https://anaconda.org). Once uploaded, your package can be installed by typing `conda install -c your_anaconda_username your-project`.\n",
+    "\n",
+    "You need to register at anaconda (fill out the form to `Sign Up`) which will create a username and password. You will then need to install the following packages\n",
+    "\n",
+    "```\n",
+    "pip install anaconda-client conda-build conda-verify\n",
+    "```\n",
+    "\n",
+    "Before running the anaconda uploader, you need to login to conda using the CLI command (you will be prompted to enter your username and password)\n",
+    "\n",
+    "```\n",
+    "anaconda login\n",
+    "```\n",
+    "\n",
+    "To upload to anaconda, just type `nbdev_conda` in your project root directory."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Upload to pypi and conda\n",
     "\n",
-    "The command `nbdev_release` from the root of your nbdev repo will bump the version of your module and upload your project to both conda and pypi."
+    "The command `nbdev_release_both` from the root of your nbdev repo will upload your project to both conda and pypi."
    ]
   },
   {


### PR DESCRIPTION
I had some trouble with conda installation because the tutorial was incomplete. I added some instructions that would have helped me.
