### PR TITLE
use `ValueError` instead of `NotImplementedError` in `nbdev.doclinks._iter_py_cells`

### DIFF
--- a/nbdev/doclinks.py
+++ b/nbdev/doclinks.py
@@ -50,9 +50,8 @@ def _iter_py_cells(p):
     for cell in cells[1:]:
         top,code = cell.split('\n', 1)
         try: nb,idx = top.split()
-        except ValueError:
-            raise NotImplementedError(f"Unexpected format in '{p}' at cell:\n```\n# %% {cell.strip()}.\n```\n"
-                                      "The expected format is: '# %% {nb_path} {cell_idx}'.")
+        except ValueError: raise ValueError(f"Unexpected format in '{p}' at cell:\n```\n# %% {cell.strip()}.\n```\n"
+                                            "The expected format is: '# %% {nb_path} {cell_idx}'.")
         nb_path = None if nb=='auto' else (p.parent/nb).resolve()  # NB paths are stored relative to .py file
         if code.endswith('\n'): code=code[:-1]
         yield AttrDict(nb=nb, idx=int(idx), code=code, nb_path=nb_path, py_path=p.resolve())

--- a/nbs/api/doclinks.ipynb
+++ b/nbs/api/doclinks.ipynb
@@ -138,9 +138,8 @@
     "    for cell in cells[1:]:\n",
     "        top,code = cell.split('\\n', 1)\n",
     "        try: nb,idx = top.split()\n",
-    "        except ValueError:\n",
-    "            raise NotImplementedError(f\"Unexpected format in '{p}' at cell:\\n```\\n# %% {cell.strip()}.\\n```\\n\"\n",
-    "                                      \"The expected format is: '# %% {nb_path} {cell_idx}'.\")\n",
+    "        except ValueError: raise ValueError(f\"Unexpected format in '{p}' at cell:\\n```\\n# %% {cell.strip()}.\\n```\\n\"\n",
+    "                                            \"The expected format is: '# %% {nb_path} {cell_idx}'.\")\n",
     "        nb_path = None if nb=='auto' else (p.parent/nb).resolve()  # NB paths are stored relative to .py file\n",
     "        if code.endswith('\\n'): code=code[:-1]\n",
     "        yield AttrDict(nb=nb, idx=int(idx), code=code, nb_path=nb_path, py_path=p.resolve())"


### PR DESCRIPTION
addresses https://github.com/fastai/nbdev/pull/1211#issuecomment-1307715432:

> Lgtm, except perhaps use a different exception. The one you picked is mainly for abstract classes