### PR TITLE
fix regex in `nbdev.doclinks._nbpath2html`

### DIFF
--- a/nbdev/doclinks.py
+++ b/nbdev/doclinks.py
@@ -58,7 +58,7 @@ def _iter_py_cells(p):
         yield AttrDict(nb=nb, idx=int(idx), code=code, nb_path=nb_path, py_path=p.resolve())
 
 # %% ../nbs/api/doclinks.ipynb 11
-def _nbpath2html(p): return p.with_name(re.sub(r'\d+[a-zA-Z0-9]+_', '', p.name.lower())).with_suffix('.html')
+def _nbpath2html(p): return p.with_name(re.sub(r'^\d+[a-zA-Z0-9]*_', '', p.name.lower())).with_suffix('.html')
 
 # %% ../nbs/api/doclinks.ipynb 13
 def _get_modidx(py_path, code_root, nbs_path):

--- a/nbs/api/doclinks.ipynb
+++ b/nbs/api/doclinks.ipynb
@@ -165,7 +165,7 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def _nbpath2html(p): return p.with_name(re.sub(r'\\d+[a-zA-Z0-9]+_', '', p.name.lower())).with_suffix('.html')"
+    "def _nbpath2html(p): return p.with_name(re.sub(r'^\\d+[a-zA-Z0-9]*_', '', p.name.lower())).with_suffix('.html')"
    ]
   },
   {


### PR DESCRIPTION
addresses https://github.com/fastai/nbdev/pull/1210#issuecomment-1307718436:

> afaict this is not the correct fix. The * seemed fine, for single digit prefixes. I think it just needs to be modified to only match the start of the name

fixes #1210