### PR TITLE
fix order of categories for migration

### DIFF
--- a/nbdev/migrate.py
+++ b/nbdev/migrate.py
@@ -17,7 +17,7 @@ import shutil
 # %% ../nbs/api/migrate.ipynb 5
 def _cat_slug(fmdict):
     "Get the partial slug from the category front matter."
-    slug = '/'.join(sorted(fmdict.get('categories', '')))
+    slug = '/'.join(fmdict.get('categories', ''))
     return '/' + slug if slug else '' 
 
 # %% ../nbs/api/migrate.ipynb 7

--- a/nbs/api/migrate.ipynb
+++ b/nbs/api/migrate.ipynb
@@ -80,7 +80,7 @@
     "#|export\n",
     "def _cat_slug(fmdict):\n",
     "    \"Get the partial slug from the category front matter.\"\n",
-    "    slug = '/'.join(sorted(fmdict.get('categories', '')))\n",
+    "    slug = '/'.join(fmdict.get('categories', ''))\n",
     "    return '/' + slug if slug else '' "
    ]
   },
@@ -93,7 +93,7 @@
    "source": [
     "#|hide\n",
     "_fm1 = _get_fm('../../tests/2020-09-01-fastcore.ipynb')\n",
-    "test_eq(_cat_slug(_fm1), '/fastai/fastcore')\n",
+    "test_eq(_cat_slug(_fm1), '/fastcore/fastai')\n",
     "\n",
     "_fm2 = _get_fm('../../tests/2020-02-20-test.ipynb')\n",
     "test_eq(_cat_slug(_fm2), '/jupyter')"


### PR DESCRIPTION
Do not sort categories when creating aliases for the URL from fastpages.  I tested it and fastpages/jekyll doesn't sort the categories. see:  https://forums.fast.ai/t/failure-to-migrate-from-fastpages-to-quarto/101466/14?u=hamelsmu