### PR TITLE
add 0 - Pre-planning status

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ licenses = {
     'gpl3': ('GNU General Public License v3', 'OSI Approved :: GNU General Public License v3 (GPLv3)'),
     'bsd3': ('BSD License', 'OSI Approved :: BSD License'),
 }
-statuses = [ '1 - Planning', '2 - Pre-Alpha', '3 - Alpha',
+statuses = [ '0 - Pre-Planning', '1 - Planning', '2 - Pre-Alpha', '3 - Alpha',
     '4 - Beta', '5 - Production/Stable', '6 - Mature', '7 - Inactive' ]
 py_versions = '3.7 3.8 3.9 3.10'.split()
 


### PR DESCRIPTION
the logic here is that setup.py uses indexing on the statuses list

since python is 0-indexed, putting `4` as status in `settings.ini` actually sets it at `5 - Production/Stable` instead of `4 - Beta` as one might expect, and so on