### PR TITLE
copy contents of _extensions folder from nbs

### DIFF
--- a/nbdev/serve.py
+++ b/nbdev/serve.py
@@ -64,6 +64,7 @@ def proc_nbs(
     path = Path(path or cfg.nbs_path)
     files = nbglob(path, func=Path, file_glob='', file_re='', **kwargs)
     if (path/'_quarto.yml').exists(): files.append(path/'_quarto.yml')
+    if (path/'_extensions').exists(): files.extend(nbglob(path/'_extensions', func=Path, file_glob='', file_re='', skip_file_re='^[.]'))
 
     # If settings.ini or filter script newer than cache folder modified, delete cache
     chk_mtime = max(cfg.config_file.stat().st_mtime, Path(__file__).stat().st_mtime)

--- a/nbs/api/serve.ipynb
+++ b/nbs/api/serve.ipynb
@@ -140,6 +140,7 @@
     "    path = Path(path or cfg.nbs_path)\n",
     "    files = nbglob(path, func=Path, file_glob='', file_re='', **kwargs)\n",
     "    if (path/'_quarto.yml').exists(): files.append(path/'_quarto.yml')\n",
+    "    if (path/'_extensions').exists(): files.extend(nbglob(path/'_extensions', func=Path, file_glob='', file_re='', skip_file_re='^[.]'))\n",
     "\n",
     "    # If settings.ini or filter script newer than cache folder modified, delete cache\n",
     "    chk_mtime = max(cfg.config_file.stat().st_mtime, Path(__file__).stat().st_mtime)\n",


### PR DESCRIPTION
`proc_nbs` was not copying folders with a prefix of `_`. added an exception for the quarto `extensions` folder.