### PR TITLE
make enabling gh-pages mandatory

### DIFF
--- a/nbs/tutorials/tutorial.ipynb
+++ b/nbs/tutorials/tutorial.ipynb
@@ -349,14 +349,23 @@
     "git add .\n",
     "git commit -m'Initial commit'\n",
     "git push\n",
-    "```"
+    "```\n",
+    "\n",
+    "\n",
+    "### Enable GitHub Pages\n",
+    "\n",
+    "You need to enable GitHub Pages for your repo by clicking on the \"Settings\" tab near the top-right of your repo page, then \"Pages\" on the left, then setting the \"Branch\" to \"gh-pages\", and finally clicking \"Save\".\n",
+    "\n",
+    "It should look similar to this after you click \"Save\":\n",
+    "\n",
+    "![](images/github-enable-pages.png){.pb-2 fig-align=\"center\" .border .rounded .shadow-sm}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It's time to see all of the goodies nbdev gives you!"
+    "Now it's time to see all of the goodies nbdev gives you!"
    ]
   },
   {
@@ -432,43 +441,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "nbdev hosts your docs on GitHub Pages---an excellent (and free!) way to host websites. \n",
-    "\n",
-    "#### Enabling GitHub Pages\n",
-    "\n",
-    ":::{.callout-important}\n",
-    "\n",
-    "##### Enabling GitHub Pages Is Not Required For Everyone\n",
-    "\n",
-    "nbdev makes a best effort to automatically enable GitHub Pages for you, however, there some cases where this is not possible such as private repos or where your organization's permissions are restricted.  If you are having trouble seeing your site, we suggest checking if Pages are enabled for your repo by following the below instructions.\n",
-    "\n",
-    "You can enable it for your repo by clicking on the \"Settings\" tab near the top-right of your repo page, then \"Pages\" on the left, then setting the \"Branch\" to \"gh-pages\", and finally clicking \"Save\".\n",
-    "\n",
-    "\n"
+    "nbdev hosts your docs on GitHub Pages---an excellent (and free!) way to host websites. "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It should look similar to this after you click \"Save\":"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "![](images/github-enable-pages.png){.pb-2 fig-align=\"center\" .border .rounded .shadow-sm}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    ":::\n",
-    "\n",
-    "Head back to GitHub Actions and you should see a new workflow run: \"pages build and deployment\". As the name says, this workflow deploys your website contents to GitHub Pages.\n",
-    "\n"
+    "Head back to GitHub Actions and you should see a new workflow run: \"pages build and deployment\". As the name says, this workflow deploys your website contents to GitHub Pages."
    ]
   },
   {


### PR DESCRIPTION
This is a docs only change @jph00 

See this discord conversation https://discord.com/channels/689892369998676007/887694559952400424/1065826828981391370

Looks like the GitHub api permissions changed here.  It was always a bit finicky, and I see lots of people getting stuck on this step -- I think it's better to make enabling pages more explicit.