### PR TITLE
allow trailing `:` in directives for YAML compliance

### DIFF
--- a/nbdev/process.py
+++ b/nbdev/process.py
@@ -33,6 +33,7 @@ def _quarto_re(lang=None): return re.compile(_dir_pre(lang) + r'\s*[\w|-]+\s*:')
 # %% ../nbs/api/03_process.ipynb 11
 def _directive(s, lang='python'):
     s = re.sub('^'+_dir_pre(lang), f"{langs[lang]}|", s)
+    if s.strip().endswith(':'): s = s.replace(':', '') # You can append colon at the end to be Quarto compliant.  Ex: #|hide:
     if ':' in s: s = s.replace(':', ': ')
     s = (s.strip()[2:]).strip().split()
     if not s: return None
@@ -70,22 +71,22 @@ def extract_directives(cell, remove=True, lang='python'):
         cell['source'] = ''.join([_norm_quarto(o, lang) for o in dirs if _quarto_re(lang).match(o) or _cell_mgc.match(o)] + code)
     return dict(L(_directive(s, lang) for s in dirs).filter())
 
-# %% ../nbs/api/03_process.ipynb 22
+# %% ../nbs/api/03_process.ipynb 21
 def opt_set(var, newval):
     "newval if newval else var"
     return newval if newval else var
 
-# %% ../nbs/api/03_process.ipynb 23
+# %% ../nbs/api/03_process.ipynb 22
 def instantiate(x, **kwargs):
     "Instantiate `x` if it's a type"
     return x(**kwargs) if isinstance(x,type) else x
 
 def _mk_procs(procs, nb): return L(procs).map(instantiate, nb=nb)
 
-# %% ../nbs/api/03_process.ipynb 24
+# %% ../nbs/api/03_process.ipynb 23
 def _is_direc(f): return getattr(f, '__name__', '-')[-1]=='_'
 
-# %% ../nbs/api/03_process.ipynb 25
+# %% ../nbs/api/03_process.ipynb 24
 class NBProcessor:
     "Process cells and nbdev comments in a notebook"
     def __init__(self, path=None, procs=None, nb=None, debug=False, rm_directives=True, process=False):
@@ -125,7 +126,7 @@ class NBProcessor:
         "Process all cells with all processors"
         for proc in self.procs: self._proc(proc)
 
-# %% ../nbs/api/03_process.ipynb 35
+# %% ../nbs/api/03_process.ipynb 34
 class Processor:
     "Base class for processors"
     def __init__(self, nb): self.nb = nb

--- a/nbs/api/03_process.ipynb
+++ b/nbs/api/03_process.ipynb
@@ -148,6 +148,7 @@
     "#|export\n",
     "def _directive(s, lang='python'):\n",
     "    s = re.sub('^'+_dir_pre(lang), f\"{langs[lang]}|\", s)\n",
+    "    if s.strip().endswith(':'): s = s.replace(':', '') # You can append colon at the end to be Quarto compliant.  Ex: #|hide:\n",
     "    if ':' in s: s = s.replace(':', ': ')\n",
     "    s = (s.strip()[2:]).strip().split()\n",
     "    if not s: return None\n",
@@ -296,25 +297,21 @@
     "# |woo: baz\n",
     "1+2\n",
     "#bar\"\"\")\n",
-    "test_eq(extract_directives(exp), {'export':['module'], 'hide':[], 'eval:': ['false'], 'foo': ['bar'], 'woo:': ['baz']})\n",
-    "test_eq(exp.source, '#|eval: false\\n# |woo: baz\\n1+2\\n#bar')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e03d189c-0629-487c-8cc5-e34268aab5f9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#|hide\n",
-    "exp  = AttrDict(source = \"\"\"\n",
-    "⍝|hide\n",
-    "⍝| foo: bar\n",
+    "\n",
+    "# this one has #|hide: with a colon at the end, wich is quarto compliant\n",
+    "exp2  = AttrDict(source = \"\"\"#|export module\n",
+    "#|eval:false\n",
+    "#| hide:\n",
+    "# | foo bar\n",
     "# |woo: baz\n",
     "1+2\n",
-    "⍝bar\"\"\")\n",
-    "test_eq(extract_directives(exp, lang='apl'), {'hide': [], 'foo:': ['bar']})"
+    "#bar\"\"\")\n",
+    "\n",
+    "_answer = {'export':['module'], 'hide':[], 'eval:': ['false'], 'foo': ['bar'], 'woo:': ['baz']}\n",
+    "\n",
+    "test_eq(extract_directives(exp), _answer)\n",
+    "test_eq(extract_directives(exp2), _answer)\n",
+    "test_eq(exp.source, '#|eval: false\\n# |woo: baz\\n1+2\\n#bar')"
    ]
   },
   {


### PR DESCRIPTION
This is to allow people to work with Quarto a bit easier.  People can add a colon after their nbdev directives so it won't break Quarto.  This is the most minimal solution I can think of to unblock folks.   I tested this as follows:

- I added a unit test to make sure directives are still extracted correctly, and did some tests on nbdev
- I tested this on a stand alone quarto project and confirmed that adding a  trailing`:` alleviated Quarto's rendering issue.

This issue keeps cropping on the Quarto side.

This is a workaround for this issue: https://github.com/quarto-dev/quarto-cli/issues/3152




