### PR TITLE
Fix encoding issue for Windows OS User especially for non-English user

### DIFF
--- a/nbs/api/02_maker.ipynb
+++ b/nbs/api/02_maker.ipynb
@@ -157,7 +157,7 @@
     "    \"Update the definition of `varname` in file `fn`, by calling `func` with the current definition\"\n",
     "    if fn:\n",
     "        fn = Path(fn)\n",
-    "        code = fn.read_text()\n",
+    "        code = fn.read_text(encoding='utf-8')\n",
     "    lines = code.splitlines()\n",
     "    v = read_var(code, varname)\n",
     "    res = func(v)\n",
@@ -568,7 +568,7 @@
     "                        \"_doc_ = 'module docstring here'\",\n",
     "                        \"#|export\\ndef a(): ...\", \"def b(): ...\")\n",
     "mm.make(cells, L([cells[2]]))\n",
-    "show_src(Path('tmp/test/testing.py').read_text())"
+    "show_src(Path('tmp/test/testing.py').read_text(encoding='utf-8'))"
    ]
   },
   {
@@ -642,7 +642,7 @@
    "source": [
     "cells = make_code_cells(\"from __future__ import print_function\", \"#|export\\ndef a(): ...\", \"#|export\\nclass A:\")\n",
     "am.make(cells)\n",
-    "show_src(Path('tmp/test/testing_noall.py').read_text())"
+    "show_src(Path('tmp/test/testing_noall.py').read_text(encoding='utf-8'))"
    ]
   },
   {
@@ -728,7 +728,7 @@
     }
    ],
    "source": [
-    "show_src(Path('tmp/test/testing.py').read_text())"
+    "show_src(Path('tmp/test/testing.py').read_text(encoding='utf-8'))"
    ]
   },
   {
@@ -799,7 +799,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }

--- a/nbs/api/05_doclinks.ipynb
+++ b/nbs/api/05_doclinks.ipynb
@@ -134,7 +134,7 @@
     "def _iter_py_cells(p):\n",
     "    \"Yield cells from an exported Python file.\"\n",
     "    p = Path(p)\n",
-    "    cells = p.read_text().split(\"\\n# %% \")\n",
+    "    cells = p.read_text(encoding='utf-8').split(\"\\n# %% \")\n",
     "    for cell in cells[1:]:\n",
     "        top,code = cell.split('\\n', 1)\n",
     "        try:\n",
@@ -234,7 +234,7 @@
     "    idxfile = dest/'_modidx.py'\n",
     "    if skip_exists and idxfile.exists(): return\n",
     "    with contextlib.suppress(FileNotFoundError): idxfile.unlink()\n",
-    "    if idxfile.exists(): res = exec_local(idxfile.read_text(), 'd')\n",
+    "    if idxfile.exists(): res = exec_local(idxfile.read_text(encoding='utf-8'), 'd')\n",
     "    else: res = dict(syms={}, settings={}) \n",
     "    res['settings'] = {k:v for k,v in get_config().d.items()\n",
     "                       if k in ('doc_host','doc_baseurl','lib_path','git_url','branch')}\n",
@@ -410,7 +410,7 @@
     "def _get_exps(mod):\n",
     "    mf = _find_mod(mod)\n",
     "    if not mf: return {}\n",
-    "    txt = mf.read_text()\n",
+    "    txt = mf.read_text(encoding='utf-8')\n",
     "    _def_types = ast.FunctionDef,ast.AsyncFunctionDef,ast.ClassDef\n",
     "    d = {}\n",
     "    for tree in ast.parse(txt).body:\n",
@@ -823,7 +823,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }

--- a/nbs/api/07_merge.ipynb
+++ b/nbs/api/07_merge.ipynb
@@ -199,7 +199,7 @@
    ],
    "source": [
     "broken = Path('../../tests/example.ipynb.broken')\n",
-    "tst_nb = broken.read_text()\n",
+    "tst_nb = broken.read_text(encoding='utf-8')\n",
     "print(tst_nb)"
    ]
   },
@@ -488,7 +488,7 @@
     "    \"Create working notebook from conflicted notebook `nbname`\"\n",
     "    nbname = Path(nbname)\n",
     "    if not nobackup and not outname: shutil.copy(nbname, nbname.with_suffix('.ipynb.bak'))\n",
-    "    nbtxt = nbname.read_text()\n",
+    "    nbtxt = nbname.read_text(encoding='utf-8')\n",
     "    a,b,branch1,branch2 = unpatch(nbtxt)\n",
     "    ac,bc = dict2nb(loads(a)),dict2nb(loads(b))\n",
     "    dest = bc if theirs else ac\n",
@@ -560,7 +560,7 @@
     "    for d in ('apply','merge'):\n",
     "        d = Path(f'.git/rebase-{d}')\n",
     "        if d.is_dir():\n",
-    "            cmt = (d/'orig-head').read_text()\n",
+    "            cmt = (d/'orig-head').read_text(encoding='utf-8')\n",
     "            msg = run(f'git show-branch --no-name {cmt}')\n",
     "            return f'{cmt[:7]} ({msg})'"
    ]
@@ -635,7 +635,7 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }

--- a/nbs/api/08_showdoc.ipynb
+++ b/nbs/api/08_showdoc.ipynb
@@ -1365,7 +1365,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }

--- a/nbs/api/17_serve.ipynb
+++ b/nbs/api/17_serve.ipynb
@@ -66,8 +66,8 @@
     "    \"Is `path` a py script starting with frontmatter?\"\n",
     "    path = Path(path)\n",
     "    if not path.suffix=='.py': return\n",
-    "    p = ast.parse(path.read_text())\n",
-    "#     try: p = ast.parse(path.read_text())\n",
+    "    p = ast.parse(path.read_text(encoding='utf-8'))\n",
+    "#     try: p = ast.parse(path.read_text(encoding='utf-8'))\n",
     "#     except: return\n",
     "    if not p.body: return\n",
     "    a = p.body[0]\n",
@@ -196,7 +196,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }


### PR DESCRIPTION
I am a windows os user in South Korea.
When I try to develop a small niche package using nbdev I faced an encoding problem.

As you may know, the default encoding for Korean in Windows OS is cp949. Therefore, when nbdev using Path.read_text from pathlib, their default encoding is cp949 and it causes a decoding error.

The simplest solution that I can figure out is explicitly set encoding for Path.read_text as 'utf-8'.

I believe it will not cause any change for most of users, at the same time it prevent not only Korean but also Japanese or other language users on Windows OS from encoding issues.

I hope this can help more Korean users enhance their productivity by nbdev.