### PR TITLE
Correct explanation for fname=None

### DIFF
--- a/nbs/api/11_clean.ipynb
+++ b/nbs/api/11_clean.ipynb
@@ -405,7 +405,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default (`fname` left to `None`), all the notebooks in `lib_folder` are cleaned. You can opt in to fully clean the notebook by removing every bit of metadata and the cell outputs by passing `clear_all=True`.\n",
+    "By default (`fname` left to `None`), all the notebooks in `config.nbs_path` are cleaned. You can opt in to fully clean the notebook by removing every bit of metadata and the cell outputs by passing `clear_all=True`.\n",
     "\n",
     "If you want to keep some keys in the main notebook metadata you can set `allowed_metadata_keys` in `settings.ini`.\n",
     "Similarly for cell level metadata use: `allowed_cell_metadata_keys`. For example, to preserve both `k1` and `k2` at both the notebook and cell level adding the following in `settings.ini`:\n",


### PR DESCRIPTION
the function is cleaning all notebooks in `config.nbs_path`, not all notebooks in `lib_folder`.