### PR TITLE
Update GitHub PAT documentation

### DIFF
--- a/nbdev/config.py
+++ b/nbdev/config.py
@@ -91,7 +91,7 @@ def _get_info(owner, repo, default_branch='main', default_kw='nbdev'):
         msg= [f"""Could not access repo: {owner}/{repo} to find your default branch - `{default_branch}` assumed.
 Edit `settings.ini` if this is incorrect.
 In the future, you can allow nbdev to see private repos by setting the environment variable GITHUB_TOKEN as described here:
-https://nbdev.fast.ai/cli.html#Using-nbdev_new-with-private-repos"""]
+https://nbdev.fast.ai/api/release.html#setup"""]
         print(''.join(msg))
         return default_branch,default_kw,''
     

--- a/nbs/api/01_config.ipynb
+++ b/nbs/api/01_config.ipynb
@@ -194,7 +194,7 @@
     "        msg= [f\"\"\"Could not access repo: {owner}/{repo} to find your default branch - `{default_branch}` assumed.\n",
     "Edit `settings.ini` if this is incorrect.\n",
     "In the future, you can allow nbdev to see private repos by setting the environment variable GITHUB_TOKEN as described here:\n",
-    "https://nbdev.fast.ai/cli.html#Using-nbdev_new-with-private-repos\"\"\"]\n",
+    "https://nbdev.fast.ai/api/release.html#setup\"\"\"]\n",
     "        print(''.join(msg))\n",
     "        return default_branch,default_kw,''\n",
     "    \n",

--- a/nbs/api/18_release.ipynb
+++ b/nbs/api/18_release.ipynb
@@ -69,13 +69,13 @@
     "\n",
     "<img alt=\"Copying your token\" width=\"743\" caption=\"Copying your token\" src=\"images/token.png\">\n",
     "\n",
-    "Paste that token into a file called `token` into the root of your repo. You can run the following in your terminal (`cd` to the root of your repo first) to create that file:\n",
+    "It’s easiest to save the token as an environment variable `GITHUB_TOKEN` that can be automatically accessed. We recommend you do this is by adding the following to the end of your `.bashrc` or `.zshrc` file:\n",
     "\n",
-    "    echo XXX > token\n",
+    "```bash\n",
+    "export GITHUB_TOKEN=xxx\n",
+    "```\n",
     "\n",
-    "Replace *XXX* above with the token you copied. Also, ensure that this file isn't added to git, by running this in your terminal:\n",
-    "\n",
-    "    echo token >> .gitignore"
+    "…and then replace the `xxx` with the token you just copied. It will automatically be avaialble whenever you start a new shell (but don’t forget to `source` that file or open a new shell after you change it)."
    ]
   },
   {
@@ -841,9 +841,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/nbs/api/18_release.ipynb
+++ b/nbs/api/18_release.ipynb
@@ -75,7 +75,7 @@
     "export GITHUB_TOKEN=xxx\n",
     "```\n",
     "\n",
-    "…and then replace the `xxx` with the token you just copied. It will automatically be avaialble whenever you start a new shell (but don’t forget to `source` that file or open a new shell after you change it)."
+    "…and then replace the `xxx` with the token you just copied. It will automatically be avaialble whenever you start a new shell (but don’t forget to `source` that file or open a new shell after you change it.)."
    ]
   },
   {
@@ -841,21 +841,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Should address #1323.

It looks like the documentation is out of date, and recommends some insecure practices with the user's GitHub Personal Access Token. I've made some changes to the `nbs/api/01_config.ipynb` and `nbs/api/18_release.ipynb` notebooks that hopefully address these issues.