### PR TITLE
add parenthesis to serve.proc_nbs

### DIFF
--- a/nbdev/serve.py
+++ b/nbdev/serve.py
@@ -70,7 +70,7 @@ def proc_nbs(
     chk_mtime = max(cfg.config_file.stat().st_mtime, Path(__file__).stat().st_mtime)
     cache.mkdir(parents=True, exist_ok=True)
     cache_mtime = cache.stat().st_mtime
-    if force or (cache.exists and cache_mtime<chk_mtime): rmtree(cache)
+    if force or (cache.exists() and cache_mtime<chk_mtime): rmtree(cache)
 
     files = files.map(_proc_file, mtime=cache_mtime, cache=cache, path=path).filter()
     kw = {} if IN_NOTEBOOK else {'method':'spawn'}

--- a/nbs/api/17_serve.ipynb
+++ b/nbs/api/17_serve.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "f305fea5",
    "metadata": {},
    "outputs": [],
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "6899a335",
    "metadata": {},
    "outputs": [],
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "32c11e55",
    "metadata": {},
    "outputs": [],
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "65766a33",
    "metadata": {},
    "outputs": [],
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "abc3835a",
    "metadata": {},
    "outputs": [],
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "8b3b08f7",
    "metadata": {},
    "outputs": [],
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "14463227",
    "metadata": {},
    "outputs": [],
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "1745c2c3",
    "metadata": {},
    "outputs": [],
@@ -176,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "04dd6d30",
    "metadata": {},
    "outputs": [],
@@ -196,21 +196,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/nbs/api/17_serve.ipynb
+++ b/nbs/api/17_serve.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "f305fea5",
    "metadata": {},
    "outputs": [],
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "6899a335",
    "metadata": {},
    "outputs": [],
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "32c11e55",
    "metadata": {},
    "outputs": [],
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "65766a33",
    "metadata": {},
    "outputs": [],
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "abc3835a",
    "metadata": {},
    "outputs": [],
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "8b3b08f7",
    "metadata": {},
    "outputs": [],
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "14463227",
    "metadata": {},
    "outputs": [],
@@ -146,7 +146,7 @@
     "    chk_mtime = max(cfg.config_file.stat().st_mtime, Path(__file__).stat().st_mtime)\n",
     "    cache.mkdir(parents=True, exist_ok=True)\n",
     "    cache_mtime = cache.stat().st_mtime\n",
-    "    if force or (cache.exists and cache_mtime<chk_mtime): rmtree(cache)\n",
+    "    if force or (cache.exists() and cache_mtime<chk_mtime): rmtree(cache)\n",
     "\n",
     "    files = files.map(_proc_file, mtime=cache_mtime, cache=cache, path=path).filter()\n",
     "    kw = {} if IN_NOTEBOOK else {'method':'spawn'}\n",
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "1745c2c3",
    "metadata": {},
    "outputs": [],
@@ -176,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "04dd6d30",
    "metadata": {},
    "outputs": [],
@@ -196,9 +196,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
While I was looking at another issue, I noticed that we are missing parenthesis on one of the .exists function calls.  I pointed this out and Jeremy asked me to put in a PR to fix.  

I'm going to just put in the single change that I mentioned, but I also noticed that the functions in serve aren't really being tested either (at least in isolation).  I was looking at adding some tests, but I think it will be challenging with the current function because we rely on the cfg.config_path. I believe we could make it a lot easier to test by using a cache_path in a similar way to how we use path for nbs currently.  If we made that more flexible, we could create a temporary directory and point to that directory and then ensure that the behavior is how we expect it to be. If there is interest in something like that, let me know and I would be happy to work on it, but I didn't want to make this PR murky since it's so straightforward.  
