### PR TITLE
Fix sync for nested libraries

### DIFF
--- a/nbdev/sync.py
+++ b/nbdev/sync.py
@@ -19,7 +19,7 @@ from fastcore.script import *
 from fastcore.xtras import *
 
 import ast
-from importlib import import_module
+import importlib
 
 # %% ../nbs/api/06_sync.ipynb
 def absolute_import(name, fname, level):
@@ -32,7 +32,10 @@ def absolute_import(name, fname, level):
 # %% ../nbs/api/06_sync.ipynb
 @functools.lru_cache(maxsize=None)
 def _mod_files():
-    midx = import_module(f'{get_config().lib_path.name}._modidx')
+    midx_spec = importlib.util.spec_from_file_location("_modidx", get_config().lib_path / "_modidx.py")
+    midx = importlib.util.module_from_spec(midx_spec)
+    midx_spec.loader.exec_module(midx)
+
     return L(files for mod in midx.d['syms'].values() for _,files in mod.values()).unique()
 
 # %% ../nbs/api/06_sync.ipynb

--- a/nbs/api/06_sync.ipynb
+++ b/nbs/api/06_sync.ipynb
@@ -46,7 +46,7 @@
     "from fastcore.xtras import *\n",
     "\n",
     "import ast\n",
-    "from importlib import import_module"
+    "import importlib"
    ]
   },
   {
@@ -98,7 +98,10 @@
     "#|export\n",
     "@functools.lru_cache(maxsize=None)\n",
     "def _mod_files():\n",
-    "    midx = import_module(f'{get_config().lib_path.name}._modidx')\n",
+    "    midx_spec = importlib.util.spec_from_file_location(\"_modidx\", get_config().lib_path / \"_modidx.py\")\n",
+    "    midx = importlib.util.module_from_spec(midx_spec)\n",
+    "    midx_spec.loader.exec_module(midx)\n",
+    "\n",
     "    return L(files for mod in midx.d['syms'].values() for _,files in mod.values()).unique()"
    ]
   },


### PR DESCRIPTION
A fix for https://github.com/fastai/nbdev/issues/1393. In essence this fixes it by using the complete library path for importing the modidx file rather than just grabbing the lowest level subdirectory from the path.

I'm not entirely sure this is the _right_ fix for the problem, but in the event that it is hopefully it makes your lives very easy.