### PR TITLE
Fixes for Python 3.12 pkg_resources

### DIFF
--- a/nbdev/doclinks.py
+++ b/nbdev/doclinks.py
@@ -14,7 +14,7 @@ from fastcore.utils import *
 from fastcore.meta import delegates
 
 import ast,contextlib
-import pkg_resources,importlib
+import importlib
 from astunparse import unparse
 
 from pprint import pformat
@@ -201,7 +201,7 @@ class NbdevLookup:
         strip_libs = L(strip_libs)
         if incl_libs is not None: incl_libs = (L(incl_libs)+strip_libs).unique()
         # Dict from lib name to _nbdev module for incl_libs (defaults to all)
-        self.entries = {o.name: _qual_syms(o.resolve()) for o in list(pkg_resources.iter_entry_points(group='nbdev'))
+        self.entries = {o.name: _qual_syms(o.load()) for o in list(importlib.metadata.entry_points(group='nbdev'))
                        if incl_libs is None or o.dist.key in incl_libs}
         py_syms = merge(*L(o['syms'].values() for o in self.entries.values()).concat())
         for m in strip_libs:

--- a/nbs/api/05_doclinks.ipynb
+++ b/nbs/api/05_doclinks.ipynb
@@ -35,7 +35,7 @@
     "from fastcore.meta import delegates\n",
     "\n",
     "import ast,contextlib\n",
-    "import pkg_resources,importlib\n",
+    "import importlib\n",
     "from astunparse import unparse\n",
     "\n",
     "from pprint import pformat\n",
@@ -53,7 +53,6 @@
     "from IPython.display import Markdown,display\n",
     "from fastcore.test import *\n",
     "from pdb import set_trace\n",
-    "from importlib import reload\n",
     "from nbdev.showdoc import show_doc"
    ]
   },
@@ -484,7 +483,7 @@
     "        strip_libs = L(strip_libs)\n",
     "        if incl_libs is not None: incl_libs = (L(incl_libs)+strip_libs).unique()\n",
     "        # Dict from lib name to _nbdev module for incl_libs (defaults to all)\n",
-    "        self.entries = {o.name: _qual_syms(o.resolve()) for o in list(pkg_resources.iter_entry_points(group='nbdev'))\n",
+    "        self.entries = {o.name: _qual_syms(o.load()) for o in list(importlib.metadata.entry_points(group='nbdev'))\n",
     "                       if incl_libs is None or o.dist.key in incl_libs}\n",
     "        py_syms = merge(*L(o['syms'].values() for o in self.entries.values()).concat())\n",
     "        for m in strip_libs:\n",

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ import shlex
 from configparser import ConfigParser
 
 import setuptools
-from pkg_resources import parse_version
+from packaging.version import Version
 
-assert parse_version(setuptools.__version__)>=parse_version('36.2')
+assert Version(setuptools.__version__)>=Version('36.2')
 
 # note: all settings are in settings.ini; edit there, not here
 config = ConfigParser(delimiters=['='])


### PR DESCRIPTION
Fixing ModuleNotFoundError with Python 3.12.2:

`ModuleNotFoundError: No module named 'pkg_resources'`

Similar to https://github.com/fastai/fastcore/pull/542 (deprecation of pkg_resources)