### PR TITLE
fix: request jupyterlab installation, not jupyter (outdated metapackage)

### DIFF
--- a/nbdev/clean.py
+++ b/nbdev/clean.py
@@ -28,7 +28,7 @@ def nbdev_trust(
     try: from nbformat.sign import NotebookNotary
     except:
         import warnings
-        warnings.warn("Please install jupyter and try again")
+        warnings.warn("Please install jupyterlab and try again")
         return
     from nbformat import read
 

--- a/nbs/api/11_clean.ipynb
+++ b/nbs/api/11_clean.ipynb
@@ -80,7 +80,7 @@
     "    try: from nbformat.sign import NotebookNotary\n",
     "    except:\n",
     "        import warnings\n",
-    "        warnings.warn(\"Please install jupyter and try again\")\n",
+    "        warnings.warn(\"Please install jupyterlab and try again\")\n",
     "        return\n",
     "    from nbformat import read\n",
     "\n",


### PR DESCRIPTION
The fact that the error message said `jupyter` not `jupyterlab` made me install the wrong package. `jupyter` is a really outdated metapackage (last update 2015).