### PR TITLE
Update tutorial.ipynb

### DIFF
--- a/nbs/tutorials/tutorial.ipynb
+++ b/nbs/tutorials/tutorial.ipynb
@@ -605,7 +605,7 @@
    "source": [
     "You should now create your package from your notebook by running:\n",
     "\n",
-    "```shell\n",
+    "```sh\n",
     "nbdev_export\n",
     "```\n",
     "\n",


### PR DESCRIPTION
Use `sh` instead of `shell` for consistent pre-formatted code formatting.