### PR TITLE
Feature: add support for .py files in py:percent format

### DIFF
--- a/nbdev/process.py
+++ b/nbdev/process.py
@@ -90,7 +90,21 @@ def _is_direc(f): return getattr(f, '__name__', '-')[-1]=='_'
 class NBProcessor:
     "Process cells and nbdev comments in a notebook"
     def __init__(self, path=None, procs=None, nb=None, debug=False, rm_directives=True, process=False):
-        self.nb = read_nb(path) if nb is None else nb
+        
+        if nb is None:
+            if str(path).endswith(".py"):
+                import jupytext
+                import nbformat
+                import tempfile
+                nb_converted = jupytext.read(path)
+                with tempfile.NamedTemporaryFile(delete=True, suffix=".ipynb") as temp_file:
+                    nbformat.write(nb_converted, temp_file.name)
+                    self.nb = read_nb(temp_file.name) if nb is None else nb
+            else:
+                self.nb = read_nb(path)
+        else:
+            self.nb = nb
+            
         self.lang = nb_lang(self.nb)
         for cell in self.nb.cells: cell.directives_ = extract_directives(cell, remove=rm_directives, lang=self.lang)
         self.procs = _mk_procs(procs, nb=self.nb)

--- a/nbdev/process.py
+++ b/nbdev/process.py
@@ -14,6 +14,8 @@ from fastcore.imports import *
 
 from collections import defaultdict
 
+import jupytext, nbformat, tempfile
+
 # %% ../nbs/api/03_process.ipynb 6
 # from https://github.com/quarto-dev/quarto-cli/blob/main/src/resources/jupyter/notebook.py
 langs = defaultdict(
@@ -93,9 +95,6 @@ class NBProcessor:
         
         if nb is None:
             if str(path).endswith(".py"):
-                import jupytext
-                import nbformat
-                import tempfile
                 nb_converted = jupytext.read(path)
                 with tempfile.NamedTemporaryFile(delete=True, suffix=".ipynb") as temp_file:
                     nbformat.write(nb_converted, temp_file.name)

--- a/nbs/api/03_process.ipynb
+++ b/nbs/api/03_process.ipynb
@@ -37,7 +37,9 @@
     "from fastcore.script import *\n",
     "from fastcore.imports import *\n",
     "\n",
-    "from collections import defaultdict"
+    "from collections import defaultdict\n",
+    "\n",
+    "import jupytext, nbformat, tempfile"
    ]
   },
   {
@@ -367,9 +369,6 @@
     "        \n",
     "        if nb is None:\n",
     "            if str(path).endswith(\".py\"):\n",
-    "                import jupytext\n",
-    "                import nbformat\n",
-    "                import tempfile\n",
     "                nb_converted = jupytext.read(path)\n",
     "                with tempfile.NamedTemporaryFile(delete=True, suffix=\".ipynb\") as temp_file:\n",
     "                    nbformat.write(nb_converted, temp_file.name)\n",

--- a/nbs/api/03_process.ipynb
+++ b/nbs/api/03_process.ipynb
@@ -364,7 +364,21 @@
     "class NBProcessor:\n",
     "    \"Process cells and nbdev comments in a notebook\"\n",
     "    def __init__(self, path=None, procs=None, nb=None, debug=False, rm_directives=True, process=False):\n",
-    "        self.nb = read_nb(path) if nb is None else nb\n",
+    "        \n",
+    "        if nb is None:\n",
+    "            if str(path).endswith(\".py\"):\n",
+    "                import jupytext\n",
+    "                import nbformat\n",
+    "                import tempfile\n",
+    "                nb_converted = jupytext.read(path)\n",
+    "                with tempfile.NamedTemporaryFile(delete=True, suffix=\".ipynb\") as temp_file:\n",
+    "                    nbformat.write(nb_converted, temp_file.name)\n",
+    "                    self.nb = read_nb(temp_file.name) if nb is None else nb\n",
+    "            else:\n",
+    "                self.nb = read_nb(path)\n",
+    "        else:\n",
+    "            self.nb = nb\n",
+    "            \n",
     "        self.lang = nb_lang(self.nb)\n",
     "        for cell in self.nb.cells: cell.directives_ = extract_directives(cell, remove=rm_directives, lang=self.lang)\n",
     "        self.procs = _mk_procs(procs, nb=self.nb)\n",
@@ -641,14 +655,6 @@
     "g = exec_new('import nbdev.process')\n",
     "assert hasattr(g['nbdev'].process, 'NBProcessor')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "af6db102-2447-49ba-94d9-bfebfb48c0f0",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/nbs/api/04_export.ipynb
+++ b/nbs/api/04_export.ipynb
@@ -320,6 +320,44 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Let's check if it is possible to export a `.py` file using the [`percent`](https://jupytext.readthedocs.io/en/latest/formats-scripts.html) format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "perc_py = \"\"\"\n",
+    "#%%\n",
+    "#|default_exp perc\n",
+    "\n",
+    "#%%\n",
+    "#|export\n",
+    "print(\"Hello world\")\n",
+    "\"\"\"\n",
+    "\n",
+    "with tempfile.TemporaryDirectory() as temp_dir:\n",
+    "    with open(f\"{temp_dir}/perc.py\", \"w\") as f: f.write(perc_py)\n",
+    "    nb_export(f\"{temp_dir}/perc.py\", f\"{temp_dir}/perc_test\")\n",
+    "    \n",
+    "    !cat {temp_dir}/perc_test/perc.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Export -"
    ]
   },
@@ -336,13 +374,6 @@
     "g = exec_new('import nbdev.export')\n",
     "assert hasattr(g['nbdev'].export, 'nb_export')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ language = English
 custom_sidebar = True
 license = apache2
 status = 5
-requirements = fastcore>=1.5.27 execnb>=0.1.4 astunparse ghapi>=1.0.3 watchdog asttokens
+requirements = fastcore>=1.5.27 execnb>=0.1.4 astunparse ghapi>=1.0.3 watchdog asttokens jupytext nbformat
 pip_requirements = PyYAML
 conda_requirements = pyyaml
 conda_user = fastai


### PR DESCRIPTION
- Introduces the ability to handle .py files as py:percent files within nbdev.
   - Does this by converting .py files to .ipynb format as an intermediate step in `NBProcessor.__init__`
- Added example of usage in 'nbs/api/04_export.ipynb'.

Can export all *.py files by running `nbdev_export --file_glob '*.py'`

See https://jupytext.readthedocs.io/en/latest/formats-scripts.html for info on the `py:percent` format.