### PR TITLE
Export on modified only bug fix

### DIFF
--- a/nbdev/cli.py
+++ b/nbdev/cli.py
@@ -186,7 +186,7 @@ def watch_export(nbs:str=None, # Nb directory to watch for changes
     def _export(e,lib=lib):
         p = e.src_path
         if (not '.ipynb_checkpoints' in p and p.endswith('.ipynb') and not Path(p).name.startswith('.~')):
-            run(f'nb_export --lib_path {lib} "{p}"')
+            if e.event_type == 'modified': run(f'nb_export --lib_path {lib} "{p}"')
     with fs_watchdog(_export, nbs):
         while True: time.sleep(1)
 

--- a/nbs/api/13_cli.ipynb
+++ b/nbs/api/13_cli.ipynb
@@ -328,7 +328,7 @@
     "    def _export(e,lib=lib):\n",
     "        p = e.src_path\n",
     "        if (not '.ipynb_checkpoints' in p and p.endswith('.ipynb') and not Path(p).name.startswith('.~')):\n",
-    "            run(f'nb_export --lib_path {lib} \"{p}\"')\n",
+    "            if e.event_type == 'modified': run(f'nb_export --lib_path {lib} \"{p}\"')\n",
     "    with fs_watchdog(_export, nbs):\n",
     "        while True: time.sleep(1)"
    ]


### PR DESCRIPTION
@jph00 

This is the bug that you helped us debug—changed `watch_export` to only export on file modifications to prevent infinite loop on linux.