### PR TITLE
Add setuptools dependency

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ language = English
 custom_sidebar = True
 license = apache2
 status = 5
-requirements = fastcore>=1.5.27 execnb>=0.1.4 astunparse ghapi>=1.0.3 watchdog asttokens
+requirements = fastcore>=1.5.27 execnb>=0.1.4 astunparse ghapi>=1.0.3 watchdog asttokens setuptools
 pip_requirements = PyYAML
 conda_requirements = pyyaml
 conda_user = fastai


### PR DESCRIPTION
Since `nbdev` is importing stuff from`pkg_resources`, it should include `setuptools` as a dependency, otherwise this results in errors when trying to run `nbdev` commands in virtual environments for projects not managed with `setuptools` (eg `uv` or `poetry`).

Fixes #1423